### PR TITLE
20240705 Patch

### DIFF
--- a/src/app/components/na-autocomplete.tsx
+++ b/src/app/components/na-autocomplete.tsx
@@ -13,6 +13,7 @@ import {
   MdList,
   MdListItem,
   MdOutlinedTextField as MdOutlinedTextFieldBase,
+  MdRippleEffect,
 } from "../util/md3";
 import {
   autoUpdate,
@@ -239,16 +240,31 @@ export default function NAOutlinedAutoComplete({
         {icon && <MdIcon slot="leading-icon">{icon}</MdIcon>}
         <div slot="trailing-icon" className="mr-2">
           {query !== "" && !props.readOnly && (
-            <MdIconButton
+            <div
+              className="cursor-pointer relative flex items-center justify-center w-10 h-10 rounded-full"
               tabIndex={-1}
               onClick={() => {
                 handleItemSelect("");
               }}
             >
+              <MdRippleEffect />
               <MdIcon>
                 <CancelIcon />
               </MdIcon>
-            </MdIconButton>
+            </div>
+            // <MdIconButton
+            //   tabIndex={-1}
+            //   onFocus={(e) => {
+            //     console.log("focus");
+            //   }}
+            //   onClick={() => {
+            //     handleItemSelect("");
+            //   }}
+            // >
+            //   <MdIcon>
+            //     <CancelIcon />
+            //   </MdIcon>
+            // </MdIconButton>
           )}
         </div>
       </MdOutlinedTextFieldBase>

--- a/src/app/components/na-multi-autocomplete.tsx
+++ b/src/app/components/na-multi-autocomplete.tsx
@@ -32,6 +32,7 @@ import {
   MdList,
   MdListItem,
   MdOutlinedTextField as MdOutlinedTextFieldBase,
+  MdRippleEffect,
 } from "../util/md3";
 import { MdTypography } from "./typography";
 
@@ -275,16 +276,28 @@ export default function NAMultiAutoComplete({
         {icon && <MdIcon slot="leading-icon">{icon}</MdIcon>}
         <div slot="trailing-icon" className="mr-2">
           {query !== "" && !props.readOnly && (
-            <MdIconButton
+            <div
+              className="cursor-pointer relative flex items-center justify-center w-10 h-10 rounded-full"
               tabIndex={-1}
               onClick={() => {
                 handleItemSelect({ key: "", value: "" });
               }}
             >
+              <MdRippleEffect />
               <MdIcon>
                 <CancelIcon />
               </MdIcon>
-            </MdIconButton>
+            </div>
+            // <MdIconButton
+            //   tabIndex={-1}
+            //   onClick={() => {
+            //     handleItemSelect({ key: "", value: "" });
+            //   }}
+            // >
+            //   <MdIcon>
+            //     <CancelIcon />
+            //   </MdIcon>
+            // </MdIconButton>
           )}
         </div>
       </MdOutlinedTextFieldBase>

--- a/src/app/main/booking/request/step-contact-information.tsx
+++ b/src/app/main/booking/request/step-contact-information.tsx
@@ -303,7 +303,7 @@ export default function ContactInformationStep() {
                 Add Email
               </MdFilledTonalButton>
             </div>
-            <MdTypography variant="label" size="medium" className="mt-6">
+            <MdTypography variant="title" size="medium" className="mt-6">
               Email Recipient
             </MdTypography>
             <MdList className="bg-surfaceContainerLow">
@@ -325,7 +325,7 @@ export default function ContactInformationStep() {
                       slot="start"
                       checked={newEmailRecipients.includes(email)}
                     />
-                    <MdTypography variant="label" size="medium">
+                    <MdTypography variant="body" size="large">
                       {email}
                     </MdTypography>
                     <div slot="end">

--- a/src/app/main/booking/request/step-contact-information.tsx
+++ b/src/app/main/booking/request/step-contact-information.tsx
@@ -133,7 +133,7 @@ export default function ContactInformationStep() {
       <MdTypography variant="title" size="large" className="mb-6">
         Contact Information
       </MdTypography>
-      <div className="grid grid-cols-2 gap-4 w-full">
+      <div className="grid grid-cols-4 gap-4 w-full">
         <NAOutlinedTextField
           required
           error={
@@ -152,7 +152,7 @@ export default function ContactInformationStep() {
             });
           }}
         />
-        <NAOutlinedTextField
+        {/* <NAOutlinedTextField
           required
           error={
             bookingRequestStep.contactInformation.visited &&
@@ -169,7 +169,7 @@ export default function ContactInformationStep() {
               };
             });
           }}
-        />
+        /> */}
 
         <NAOutlinedTextField
           required

--- a/src/app/main/documents/si/edit/step-contact-information.tsx
+++ b/src/app/main/documents/si/edit/step-contact-information.tsx
@@ -315,7 +315,7 @@ export default function StepContactInformation() {
                 Add Email
               </MdFilledTonalButton>
             </div>
-            <MdTypography variant="label" size="medium" className="mt-6">
+            <MdTypography variant="title" size="medium" className="mt-6">
               Email Recipient
             </MdTypography>
             <MdList className="bg-surfaceContainerLow">
@@ -337,7 +337,7 @@ export default function StepContactInformation() {
                       slot="start"
                       checked={newEmailRecipients.includes(email)}
                     />
-                    <MdTypography variant="label" size="medium">
+                    <MdTypography variant="body" size="large">
                       {email}
                     </MdTypography>
                     <div slot="end">

--- a/src/app/main/documents/si/edit/step-contact-information.tsx
+++ b/src/app/main/documents/si/edit/step-contact-information.tsx
@@ -76,7 +76,7 @@ export default function StepContactInformation() {
         Contact Information
       </MdTypography>
       <div className="flex flex-col gap-6">
-        <div className="grid grid-cols-2 gap-4">
+        <div className="grid grid-cols-4 gap-4">
           <NAOutlinedTextField
             required
             error={
@@ -95,7 +95,7 @@ export default function StepContactInformation() {
               });
             }}
           />
-          <NAOutlinedTextField
+          {/* <NAOutlinedTextField
             required
             error={
               SIEditStep.contactInformation.visited &&
@@ -113,7 +113,7 @@ export default function StepContactInformation() {
                 };
               });
             }}
-          />
+          /> */}
           <NAOutlinedTextField
             required
             error={

--- a/src/app/main/documents/si/edit/step-mark-description.tsx
+++ b/src/app/main/documents/si/edit/step-mark-description.tsx
@@ -168,8 +168,6 @@ export default function StepMarkDescription() {
               SIEditStep.markDescription.visited &&
               markDescriptionStore.customsCommodity === ""
             }
-            type="textarea"
-            rows={5}
             maxInputLength={350}
             errorText="Customs Commodity is required."
             placeholder="Customs Commodity"

--- a/src/app/main/documents/si/edit/step-mark-description.tsx
+++ b/src/app/main/documents/si/edit/step-mark-description.tsx
@@ -164,12 +164,12 @@ export default function StepMarkDescription() {
         <div className="flex flex-col gap-4">
           <DetailTitle title="Customs Commodity" />
           <NAOutlinedTextField
-            error={
-              SIEditStep.markDescription.visited &&
-              markDescriptionStore.customsCommodity === ""
-            }
+            // error={
+            //   SIEditStep.markDescription.visited &&
+            //   markDescriptionStore.customsCommodity === ""
+            // }
             maxInputLength={350}
-            errorText="Customs Commodity is required."
+            // errorText="Customs Commodity is required."
             placeholder="Customs Commodity"
             value={markDescriptionStore.customsCommodity}
             handleValueChange={(value) => {


### PR DESCRIPTION
- 공통 / Multi Email Recipient Dialog의 Font Size가 디자인과 맞지 않았던 점 수정
- 공통 / AutoComplete의 Clear Button을 MdIconButton에서 Custom Component로 변경 (Clear Button의 Focus 방지)
- Booking Request / Contact Information의 Email 필드 삭제 / 구조 변경
- SI Edit / Contact Information의 Email 필드 삭제 / 구조 변경
- SI Edit / Mark&Description의 Custom Commodity를 Textarea에서 Textfield로 변경