### PR TITLE
20240902 update

### DIFF
--- a/src/app/components/logo.tsx
+++ b/src/app/components/logo.tsx
@@ -10,7 +10,7 @@ export default function Logo({
 }> & { children?: React.ReactNode }) {
   return (
     <div className="flex items-center" {...props}>
-      <div className="flex items-center ml-4">
+      <div className="flex items-center">
         <Image
           aria-label="company logo"
           src="/logo_clt.svg"

--- a/src/app/components/side-nav/side-nav.tsx
+++ b/src/app/components/side-nav/side-nav.tsx
@@ -33,7 +33,7 @@ export default function SideNavigation() {
         className={`flex items-center flex-col py-3
       ${
         pathname.split("/").includes("main") && userData.isAuthenticated
-          ? "w-20 visible"
+          ? "w-[72px] visible"
           : "w-0 invisible"
       }`}
       >

--- a/src/app/components/table/basic-table.tsx
+++ b/src/app/components/table/basic-table.tsx
@@ -374,7 +374,7 @@ export const BasicTable = ({
   // }, [instance]);
 
   return (
-    <div className="relative flex flex-col gap-4 flex-1 h-full">
+    <div className="relative flex flex-col gap-2 flex-1 h-full">
       <div className="flex items-end">
         {ActionComponent && <ActionComponent {...table} />}
         <div className="flex gap-2 items-center h-10 z-10">

--- a/src/app/header.tsx
+++ b/src/app/header.tsx
@@ -15,7 +15,7 @@ export const Header = () => {
     pathname.split("/").includes("main") && userData.isAuthenticated;
 
   return (
-    <header className="relative h-16 flex items-center px-4">
+    <header className="relative h-14 flex items-center px-6">
       <Link href={isMain ? "/main/dashboard" : "/"}>
         <Logo />
       </Link>

--- a/src/app/main/booking/request/components/container-toggle-button.tsx
+++ b/src/app/main/booking/request/components/container-toggle-button.tsx
@@ -21,7 +21,7 @@ const ContainerToggleButton = ({
 
   return (
     <div
-      className={`relative flex-1 flex flex-col gap-1 justify-center items-center py-4 rounded-lg border min-w-36 ${
+      className={`relative flex-1 flex flex-col gap-1 justify-center items-center py-2 rounded-lg border min-w-36 ${
         isSelected
           ? "border-primary bg-surfaceContainer"
           : "border-outlineVariant"

--- a/src/app/main/booking/request/page.tsx
+++ b/src/app/main/booking/request/page.tsx
@@ -211,7 +211,7 @@ function BookingRequest() {
           "min-h-[720px] "
         )}
       >
-        <div className="flex flex-col gap-4 py-6 px-4 border-r border-r-outlineVariant">
+        <div className="flex flex-col gap-4 p-4 border-r border-r-outlineVariant">
           {Object.keys(bookingRequestStepState).map((key) => {
             const item =
               bookingRequestStepState[
@@ -231,7 +231,7 @@ function BookingRequest() {
           })}
         </div>
         <Suspense>
-          <div className="flex-1 flex p-6">
+          <div className="flex-1 flex p-6 pt-4">
             {
               {
                 locationSchedule: <LoactionScheduleStep />,

--- a/src/app/main/booking/request/step-additional-information.tsx
+++ b/src/app/main/booking/request/step-additional-information.tsx
@@ -59,7 +59,7 @@ export default function AdditionalInformationStep() {
 
   return (
     <div className="w-full flex flex-col">
-      <MdTypography variant="title" size="large" className="mb-6">
+      <MdTypography variant="title" size="large" className="mb-4">
         Additional Information
       </MdTypography>
       <div className="grid grid-cols-2 gap-8">

--- a/src/app/main/booking/request/step-cargo.tsx
+++ b/src/app/main/booking/request/step-cargo.tsx
@@ -121,7 +121,7 @@ export default function CargoStep() {
 
   return (
     <div className="w-full flex flex-col">
-      <MdTypography variant="title" size="large" className="mb-6">
+      <MdTypography variant="title" size="large" className="mb-4">
         Cargo & Pick Up/Return
       </MdTypography>
       <SubTitle title="Cargo" className="mb-4" />

--- a/src/app/main/booking/request/step-contact-information.tsx
+++ b/src/app/main/booking/request/step-contact-information.tsx
@@ -130,7 +130,7 @@ export default function ContactInformationStep() {
 
   return (
     <div className="w-full">
-      <MdTypography variant="title" size="large" className="mb-6">
+      <MdTypography variant="title" size="large" className="mb-4">
         Contact Information
       </MdTypography>
       <div className="grid grid-cols-4 gap-4 w-full">

--- a/src/app/main/booking/request/step-container.tsx
+++ b/src/app/main/booking/request/step-container.tsx
@@ -244,7 +244,7 @@ export default function ContainerStep() {
       </MdTypography>
       {params.has("quoteNumber") ? (
         <>
-          <div className="w-fit mt-6">
+          <div className="w-fit mt-4">
             <ContainerToggleButton
               image={<DryContainerImage />}
               isSelected={typeSelections.includes(ContainerType.dry)}

--- a/src/app/main/booking/request/step-item.tsx
+++ b/src/app/main/booking/request/step-item.tsx
@@ -15,7 +15,7 @@ export default function StepItem({
   return (
     <div
       {...props}
-      className={`relative flex gap-4 w-[268px] p-4 rounded-lg cursor-pointer ${
+      className={`relative flex gap-4 w-[252px] p-4 rounded-lg cursor-pointer ${
         isSelected ? "bg-primary" : "bg-surfaceContainerLow"
       }`}
     >

--- a/src/app/main/booking/request/step-location-schedule.tsx
+++ b/src/app/main/booking/request/step-location-schedule.tsx
@@ -132,11 +132,11 @@ export default function LoactionScheduleStep() {
 
   return (
     <div className="flex flex-col flex-1">
-      <MdTypography variant="title" size="large" className="mb-6">
+      <MdTypography variant="title" size="large" className="mb-4">
         Location & Schedule
       </MdTypography>
       <div className="flex gap-4 flex-1">
-        <div className="flex-1 flex flex-col gap-6">
+        <div className="flex-1 flex flex-col gap-4">
           <form className="flex gap-8">
             <MdTypography
               tag="label"

--- a/src/app/main/booking/request/step-parties.tsx
+++ b/src/app/main/booking/request/step-parties.tsx
@@ -84,7 +84,7 @@ export default function PartiesStep() {
 
   return (
     <div className="w-full flex flex-col">
-      <MdTypography variant="title" size="large" className="mb-6">
+      <MdTypography variant="title" size="large" className="mb-4">
         Parties
       </MdTypography>
       <SubTitle title="Person Placing Request" className="mb-4" />
@@ -136,14 +136,13 @@ export default function PartiesStep() {
           }
         }}
       />
-      <DividerComponent className="my-6" />
+      <DividerComponent className="my-4" />
       <SubTitle title="Shipper" className="mb-4" />
       <div className="flex gap-4">
         <NAMultiAutoComplete
           label="Company Name"
           itemList={tempCompaniesData}
           required
-          maxLength={70}
           error={
             bookingRequestStep.parties.visited &&
             partiesData.shipper.name === ""
@@ -178,7 +177,6 @@ export default function PartiesStep() {
         <NAOutlinedTextField
           className="flex-1"
           label="Address"
-          maxLength={105}
           placeholder="Address (State Name, City, State & Zip Code, Country Name)"
           required
           error={
@@ -198,11 +196,10 @@ export default function PartiesStep() {
           }}
         />
       </div>
-      <SubTitle title="Freight Forwarder" className="mt-8 mb-4" />
+      <SubTitle title="Freight Forwarder" className="my-4" />
       <div className="flex gap-4 items-start">
         <NAMultiAutoComplete
           label="Company Name"
-          maxLength={70}
           itemList={tempCompaniesData}
           initialValue={{
             name: partiesData.freightForwarder.name,
@@ -233,7 +230,6 @@ export default function PartiesStep() {
         <NAOutlinedTextField
           className="flex-1"
           label="Address"
-          maxLength={105}
           placeholder="Address (State Name, City, State & Zip Code, Country Name)"
           value={partiesData.freightForwarder.address}
           handleValueChange={(value) => {
@@ -283,11 +279,10 @@ export default function PartiesStep() {
           }}
         />
       </div>
-      <SubTitle title="Consignee" className="mt-8 mb-4" />
+      <SubTitle title="Consignee" className="my-4" />
       <div className="flex gap-4">
         <NAMultiAutoComplete
           label="Company Name"
-          maxLength={70}
           itemList={tempCompaniesData}
           initialValue={{
             name: partiesData.consignee.name,
@@ -318,7 +313,6 @@ export default function PartiesStep() {
         <NAOutlinedTextField
           className="flex-1"
           label="Address"
-          maxLength={105}
           placeholder="Address (State Name, City, State & Zip Code, Country Name)"
           value={partiesData.consignee.address}
           handleValueChange={(value) => {
@@ -332,10 +326,9 @@ export default function PartiesStep() {
           }}
         />
       </div>
-      <SubTitle title="Actual" className="mt-8 mb-4" />
+      <SubTitle title="Actual" className="my-4" />
       <NAOutlinedTextField
         label="Shipper Name"
-        maxLength={105}
         value={partiesData.actualShipper}
         handleValueChange={(value) => {
           setPartiesData((prev) => ({

--- a/src/app/main/dashboard/page.tsx
+++ b/src/app/main/dashboard/page.tsx
@@ -1,15 +1,16 @@
 "use client";
 
-import { MdTypography } from "../../components/typography";
-import { MdFilledTonalIconButton, MdFilterChip, MdIcon } from "../../util/md3";
-import SettingsOutlinedIcon from "@mui/icons-material/SettingsOutlined";
+import { OverlayScrollbarsComponent } from "overlayscrollbars-react";
+import { useState } from "react";
 import { useRecoilState } from "recoil";
+
+import PageTitle from "@/app/components/title-components";
+import SettingsOutlinedIcon from "@mui/icons-material/SettingsOutlined";
+
 import { draggableState } from "../../store/dashboard.store";
-import { useEffect, useState } from "react";
+import { MdFilledTonalIconButton, MdFilterChip, MdIcon } from "../../util/md3";
 import Dashboard from "./dashboard";
 import SetDashboard from "./set-dashboard";
-import { OverlayScrollbarsComponent } from "overlayscrollbars-react";
-import PageTitle from "@/app/components/title-components";
 
 export default function MainPage() {
   const [customizabled, setCustomizabled] = useRecoilState(draggableState);
@@ -27,7 +28,6 @@ export default function MainPage() {
             <MdFilterChip
               label="Custom"
               selected={customizabled}
-              // defaultChecked={customizabled}
               onClick={() => {
                 setCustomizabled(!customizabled);
               }}

--- a/src/app/main/documents/si/edit/components/container-toggle-button.tsx
+++ b/src/app/main/documents/si/edit/components/container-toggle-button.tsx
@@ -21,7 +21,7 @@ const ContainerToggleButton = ({
 
   return (
     <div
-      className={`relative flex-1 flex flex-col gap-1 justify-center items-center  py-4 rounded-lg border ${
+      className={`relative flex-1 flex flex-col gap-1 justify-center items-center py-2 rounded-lg border ${
         isSelected ? "border-primary bg-[#19658414]" : "border-outlineVariant"
       } cursor-pointer`}
       onClick={onClick}

--- a/src/app/main/documents/si/edit/components/parties/consignee-info.tsx
+++ b/src/app/main/documents/si/edit/components/parties/consignee-info.tsx
@@ -39,7 +39,7 @@ export const ConsigneeInfo = () => {
 
   return (
     <div>
-      <div className="flex justify-between items-center mb-4">
+      <div className="flex justify-between items-center">
         <DetailTitle title="Consignee" />
         <NaToggleButton
           label="To Order"
@@ -73,7 +73,7 @@ export const ConsigneeInfo = () => {
           }}
         />
       </div>
-      <div className={`flex flex-col gap-4 mb-6`}>
+      <div className={`flex flex-col gap-4`}>
         <NAMultiAutoComplete
           label="Company Name"
           className="flex-1"
@@ -83,7 +83,6 @@ export const ConsigneeInfo = () => {
             partiesStore.consignee.companyName === ""
           }
           type="textarea"
-          maxLength={70}
           rows={2}
           errorText="Company Name is required"
           isAllowOnlyListItems={false}
@@ -160,7 +159,6 @@ export const ConsigneeInfo = () => {
           }
           errorText="Full Address is required"
           label="Address (State Name, City, State & Zip Code, Country Name)"
-          maxLength={105}
           rows={3}
           className="flex-1"
           type="textarea"
@@ -228,7 +226,6 @@ export const ConsigneeInfo = () => {
           <div className="flex gap-2">
             <NAOutlinedTextField
               label="City"
-              maxLength={30}
               value={partiesStore.consignee.addressCity || ""}
               handleValueChange={(value) => {
                 setPartiesStore((prev) => {
@@ -245,7 +242,6 @@ export const ConsigneeInfo = () => {
 
             <NAOutlinedTextField
               label="State"
-              maxLength={2}
               enableClearButton={false}
               className="w-24"
               value={partiesStore.consignee.addressState || ""}
@@ -267,7 +263,6 @@ export const ConsigneeInfo = () => {
             <NAOutlinedTextField
               label="Zip Code"
               className="w-44"
-              maxLength={10}
               value={partiesStore.consignee.addressZipCode || ""}
               handleValueChange={(value) => {
                 setPartiesStore((prev) => {
@@ -286,7 +281,6 @@ export const ConsigneeInfo = () => {
         <NAOutlinedTextField
           label="Street / P.O Box"
           className="flex-1"
-          maxLength={50}
           value={partiesStore.consignee.addressStreet || ""}
           handleValueChange={(value) => {
             setPartiesStore((prev) => {
@@ -325,7 +319,6 @@ export const ConsigneeInfo = () => {
               <Disclosure.Panel className={`grid grid-cols-4 gap-4`}>
                 <NAOutlinedTextField
                   label="EORI No"
-                  maxLength={17}
                   className="col-span-2"
                   value={partiesStore.consignee.eoriNumber || ""}
                   handleValueChange={(value) => {
@@ -342,7 +335,6 @@ export const ConsigneeInfo = () => {
                 />
                 <NAOutlinedTextField
                   label="USCC No"
-                  maxLength={30}
                   className="col-span-2"
                   value={partiesStore.consignee.usccNumber || ""}
                   handleValueChange={(value) => {
@@ -359,7 +351,6 @@ export const ConsigneeInfo = () => {
                 />
                 <NAOutlinedTextField
                   label="Tax ID"
-                  maxLength={30}
                   value={partiesStore.consignee.taxID || ""}
                   handleValueChange={(value) => {
                     setPartiesStore((prev) => {
@@ -376,7 +367,6 @@ export const ConsigneeInfo = () => {
                 <NAOutlinedTextField
                   label="Phone"
                   type="tel"
-                  maxLength={20}
                   value={partiesStore.consignee.phone || ""}
                   handleValueChange={(value) => {
                     setPartiesStore((prev) => {
@@ -393,7 +383,6 @@ export const ConsigneeInfo = () => {
                 <NAOutlinedTextField
                   label="Fax"
                   type="tel"
-                  maxLength={20}
                   value={partiesStore.consignee.fax || ""}
                   handleValueChange={(value) => {
                     setPartiesStore((prev) => {
@@ -410,7 +399,6 @@ export const ConsigneeInfo = () => {
                 <NAOutlinedTextField
                   label="Email"
                   type="email"
-                  maxLength={100}
                   className="col-span-2"
                   value={partiesStore.consignee.email || ""}
                   handleValueChange={(value) => {

--- a/src/app/main/documents/si/edit/components/parties/notify-party-info.tsx
+++ b/src/app/main/documents/si/edit/components/parties/notify-party-info.tsx
@@ -39,7 +39,7 @@ export const NotifyPartyInfo = () => {
 
   return (
     <div>
-      <div className="flex justify-between items-center mb-4">
+      <div className="flex justify-between items-center">
         <DetailTitle title="Notify Party" />
         <NaToggleButton
           label="Same as Consignee"
@@ -103,10 +103,9 @@ export const NotifyPartyInfo = () => {
           }}
         />
       </div>
-      <div className={`flex flex-col gap-4 mb-6`}>
+      <div className={`flex flex-col gap-4`}>
         <NAMultiAutoComplete
           label="Company Name"
-          maxLength={70}
           className="flex-1"
           required
           type="textarea"
@@ -187,7 +186,6 @@ export const NotifyPartyInfo = () => {
         <NAOutlinedTextField
           required
           rows={3}
-          maxLength={105}
           error={
             SIEditStep.parties.visited &&
             partiesStore.notifyParty.fullAddress === ""
@@ -261,7 +259,6 @@ export const NotifyPartyInfo = () => {
           <div className="flex gap-2">
             <NAOutlinedTextField
               label="City"
-              maxLength={30}
               value={partiesStore.notifyParty.addressCity || ""}
               handleValueChange={(value) => {
                 setPartiesStore((prev) => {
@@ -277,7 +274,6 @@ export const NotifyPartyInfo = () => {
             />
             <NAOutlinedTextField
               label="State"
-              maxLength={2}
               enableClearButton={false}
               className="w-24"
               value={partiesStore.notifyParty.addressState || ""}
@@ -298,7 +294,6 @@ export const NotifyPartyInfo = () => {
           <NAOutlinedTextField
             label="Zip Code"
             className="w-44"
-            maxLength={10}
             value={partiesStore.notifyParty.addressZipCode || ""}
             handleValueChange={(value) => {
               setPartiesStore((prev) => {
@@ -315,7 +310,6 @@ export const NotifyPartyInfo = () => {
         </div>
         <NAOutlinedTextField
           label="Street / P.O Box"
-          maxLength={50}
           className="flex-1"
           value={partiesStore.notifyParty.addressStreet || ""}
           handleValueChange={(value) => {
@@ -355,7 +349,6 @@ export const NotifyPartyInfo = () => {
               <Disclosure.Panel className={`grid grid-cols-4 gap-4`}>
                 <NAOutlinedTextField
                   label="EORI No"
-                  maxLength={17}
                   className="col-span-2"
                   value={partiesStore.notifyParty.eoriNumber || ""}
                   handleValueChange={(value) => {
@@ -372,7 +365,6 @@ export const NotifyPartyInfo = () => {
                 />
                 <NAOutlinedTextField
                   label="USCC No"
-                  maxLength={30}
                   className="col-span-2"
                   value={partiesStore.notifyParty.usccNumber || ""}
                   handleValueChange={(value) => {
@@ -389,7 +381,6 @@ export const NotifyPartyInfo = () => {
                 />
                 <NAOutlinedTextField
                   label="Tax ID"
-                  maxLength={30}
                   value={partiesStore.notifyParty.taxID || ""}
                   handleValueChange={(value) => {
                     setPartiesStore((prev) => {
@@ -406,7 +397,6 @@ export const NotifyPartyInfo = () => {
                 <NAOutlinedTextField
                   label="Phone"
                   type="tel"
-                  maxLength={20}
                   value={partiesStore.notifyParty.phone || ""}
                   handleValueChange={(value) => {
                     setPartiesStore((prev) => {
@@ -423,7 +413,6 @@ export const NotifyPartyInfo = () => {
                 <NAOutlinedTextField
                   label="Fax"
                   type="tel"
-                  maxLength={20}
                   value={partiesStore.notifyParty.fax || ""}
                   handleValueChange={(value) => {
                     setPartiesStore((prev) => {
@@ -440,7 +429,6 @@ export const NotifyPartyInfo = () => {
                 <NAOutlinedTextField
                   label="Email"
                   type="email"
-                  maxLength={100}
                   className="col-span-2"
                   value={partiesStore.notifyParty.email || ""}
                   handleValueChange={(value) => {

--- a/src/app/main/documents/si/edit/components/parties/shipper-info.tsx
+++ b/src/app/main/documents/si/edit/components/parties/shipper-info.tsx
@@ -57,7 +57,6 @@ export const ShipperInfo = () => {
           type="textarea"
           rows={2}
           isAllowOnlyListItems={false}
-          maxLength={70}
           itemList={companyList.map((company) => {
             return {
               name: company.name,
@@ -121,7 +120,6 @@ export const ShipperInfo = () => {
             SIEditStep.parties.visited &&
             partiesStore.shipper.fullAddress === ""
           }
-          maxLength={105}
           rows={3}
           errorText="Full Address is required"
           label="Address (State Name, City, State & Zip Code, Country Name)"
@@ -191,7 +189,6 @@ export const ShipperInfo = () => {
           <div className="flex gap-2">
             <NAOutlinedTextField
               label="City"
-              maxLength={30}
               value={partiesStore.shipper.addressCity || ""}
               handleValueChange={(value) => {
                 setPartiesStore((prev) => {
@@ -207,7 +204,6 @@ export const ShipperInfo = () => {
             />
             <NAOutlinedTextField
               label="State"
-              maxLength={2}
               className="w-24"
               enableClearButton={false}
               value={partiesStore.shipper.addressState || ""}
@@ -227,7 +223,6 @@ export const ShipperInfo = () => {
           <NAOutlinedTextField
             label="Zip Code"
             className="w-44"
-            maxLength={10}
             value={partiesStore.shipper.addressZipCode || ""}
             handleValueChange={(value) => {
               setPartiesStore((prev) => {
@@ -245,7 +240,6 @@ export const ShipperInfo = () => {
         <NAOutlinedTextField
           label="Street / P.O Box"
           className="col-span-4"
-          maxLength={50}
           value={partiesStore.shipper.addressStreet || ""}
           handleValueChange={(value) => {
             setPartiesStore((prev) => {
@@ -283,7 +277,6 @@ export const ShipperInfo = () => {
                 <NAOutlinedTextField
                   label="EORI No"
                   className="col-span-2"
-                  maxLength={17}
                   value={partiesStore.shipper.eoriNumber || ""}
                   handleValueChange={(value) => {
                     setPartiesStore((prev) => {
@@ -299,7 +292,6 @@ export const ShipperInfo = () => {
                 />
                 <NAOutlinedTextField
                   label="USCC No"
-                  maxLength={30}
                   className="col-span-2"
                   value={partiesStore.shipper.usccNumber || ""}
                   handleValueChange={(value) => {
@@ -316,7 +308,6 @@ export const ShipperInfo = () => {
                 />
                 <NAOutlinedTextField
                   label="Tax ID"
-                  maxLength={30}
                   value={partiesStore.shipper.taxID || ""}
                   handleValueChange={(value) => {
                     setPartiesStore((prev) => {
@@ -333,7 +324,6 @@ export const ShipperInfo = () => {
                 <NAOutlinedTextField
                   label="Phone"
                   type="tel"
-                  maxLength={20}
                   value={partiesStore.shipper.phone || ""}
                   handleValueChange={(value) => {
                     setPartiesStore((prev) => {
@@ -350,7 +340,6 @@ export const ShipperInfo = () => {
                 <NAOutlinedTextField
                   label="Fax"
                   type="tel"
-                  maxLength={20}
                   value={partiesStore.shipper.fax || ""}
                   handleValueChange={(value) => {
                     setPartiesStore((prev) => {
@@ -367,7 +356,6 @@ export const ShipperInfo = () => {
                 <NAOutlinedTextField
                   label="Email"
                   type="email"
-                  maxLength={100}
                   className="col-span-2"
                   value={partiesStore.shipper.email || ""}
                   handleValueChange={(value) => {

--- a/src/app/main/documents/si/edit/components/step-item.tsx
+++ b/src/app/main/documents/si/edit/components/step-item.tsx
@@ -15,7 +15,7 @@ export default function StepItem({
   return (
     <div
       {...props}
-      className={`relative flex gap-4 w-[268px] p-4 rounded-lg cursor-pointer ${
+      className={`relative flex gap-4 w-[252px] p-4 rounded-lg cursor-pointer ${
         isSelected ? "bg-primary" : "bg-surfaceContainerLow"
       }`}
     >

--- a/src/app/main/documents/si/edit/page.tsx
+++ b/src/app/main/documents/si/edit/page.tsx
@@ -178,7 +178,7 @@ function SIEdit() {
           "min-h-[720px]"
         )}
       >
-        <div className="flex flex-col gap-4 py-6 px-4 border-r border-r-outlineVariant">
+        <div className="flex flex-col gap-4 p-4 border-r border-r-outlineVariant">
           {Object.keys(siEditStep).map((key) => {
             const item = siEditStep[key as keyof typeof siEditStep];
             return (
@@ -197,7 +197,7 @@ function SIEdit() {
             );
           })}
         </div>
-        <div className="flex-1 flex p-6 min-h-fit">
+        <div className="flex-1 flex px-6 py-4 min-h-fit">
           {
             {
               parties: <StepParties />,

--- a/src/app/main/documents/si/edit/step-contact-information.tsx
+++ b/src/app/main/documents/si/edit/step-contact-information.tsx
@@ -72,10 +72,10 @@ export default function StepContactInformation() {
 
   return (
     <div className="w-full flex flex-col">
-      <MdTypography variant="title" size="large" className="mb-6">
+      <MdTypography variant="title" size="large" className="mb-4">
         Contact Information
       </MdTypography>
-      <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-4">
         <div className="grid grid-cols-4 gap-4">
           <NAOutlinedTextField
             required

--- a/src/app/main/documents/si/edit/step-container.tsx
+++ b/src/app/main/documents/si/edit/step-container.tsx
@@ -127,7 +127,7 @@ export default function StepContainer() {
           Container
         </MdTypography>
         <div className="flex gap-4">
-          <div className="bg-surfaceContainerHigh rounded-2xl px-4 py-1 flex items-center relative">
+          <div className="bg-surfaceContainerLow rounded-2xl px-4 py-1 flex items-center relative">
             <MdTypography
               variant="label"
               size="small"

--- a/src/app/main/documents/si/edit/step-container.tsx
+++ b/src/app/main/documents/si/edit/step-container.tsx
@@ -122,7 +122,7 @@ export default function StepContainer() {
 
   return (
     <div className="w-full flex flex-col">
-      <div className="flex items-center justify-between mb-6">
+      <div className="flex items-center justify-between mb-4">
         <MdTypography variant="title" size="large">
           Container
         </MdTypography>

--- a/src/app/main/documents/si/edit/step-mark-description.tsx
+++ b/src/app/main/documents/si/edit/step-mark-description.tsx
@@ -70,10 +70,10 @@ export default function StepMarkDescription() {
 
   return (
     <div className="w-full flex flex-col">
-      <MdTypography variant="title" size="large" className="mb-6">
+      <MdTypography variant="title" size="large" className="mb-4">
         Mark & Description
       </MdTypography>
-      <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-4">
         <div className="flex gap-6">
           <div className="flex-1 flex flex-col gap-4">
             <DetailTitle title="Mark" />

--- a/src/app/main/documents/si/edit/step-parties.tsx
+++ b/src/app/main/documents/si/edit/step-parties.tsx
@@ -18,6 +18,7 @@ import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
 import { ShipperInfo } from "./components/parties/shipper-info";
 import { ConsigneeInfo } from "./components/parties/consignee-info";
 import { NotifyPartyInfo } from "./components/parties/notify-party-info";
+import { DividerComponent } from "@/app/components/divider";
 
 export default function StepParties() {
   const setSIEditStep = useSetRecoilState(SIEditStepState);
@@ -78,7 +79,7 @@ export default function StepParties() {
   }, [setSIEditStep, ValidateRequired]);
 
   return (
-    <div className="w-full flex flex-col gap-6">
+    <div className="w-full flex flex-col gap-4">
       <MdTypography variant="title" size="large">
         Parties
       </MdTypography>
@@ -90,7 +91,6 @@ export default function StepParties() {
             label="Forwarding Agent References"
             type="textarea"
             rows={5}
-            maxLength={175}
             value={partiesStore.forwardingAgentReference || ""}
             handleValueChange={(value) => {
               setPartiesStore((prev) => {
@@ -118,15 +118,21 @@ export default function StepParties() {
             }}
           />
         </div>
+      </div>
+      <DividerComponent className="border-dotted" />
+      <div className="grid grid-cols-2 gap-6">
         <ConsigneeInfo />
         <NotifyPartyInfo />
+      </div>
+      <DividerComponent className="border-dotted" />
+
+      <div className="grid grid-cols-2 gap-6">
         <div>
           <DetailTitle title="Also Notify" className="mb-4" />
-          <div className={`mb-6`}>
+          <div>
             <MdOutlinedTextField
               label="Also Notify"
               type="textarea"
-              maxLength={175}
               className="w-full"
               rows={5}
               value={partiesStore.notifyParty.alsoNotify || ""}
@@ -170,7 +176,6 @@ export default function StepParties() {
               label="Export References"
               type="textarea"
               rows={5}
-              maxLength={175}
               value={partiesStore.exportReference || ""}
               handleValueChange={(value) => {
                 setPartiesStore((prev) => {

--- a/src/app/main/documents/si/edit/step-routeBL.tsx
+++ b/src/app/main/documents/si/edit/step-routeBL.tsx
@@ -75,8 +75,8 @@ export default function StepRouteBL() {
   }, []);
 
   return (
-    <div className="w-full flex flex-col gap-6">
-      <MdTypography variant="title" size="large" className="mb-6">
+    <div className="w-full flex flex-col gap-4">
+      <MdTypography variant="title" size="large">
         Route & BL Information
       </MdTypography>
       <div className="grid grid-cols-[1fr_1fr_auto] gap-4">

--- a/src/app/styles/base.module.css
+++ b/src/app/styles/base.module.css
@@ -1,6 +1,6 @@
 .container {
   /*max-w-[1400px] Deprecated*/
-  @apply w-full p-6 flex flex-col flex-1 gap-4;
+  @apply w-full p-5 pt-2 flex flex-col flex-1 gap-4;
 }
 
 .area {

--- a/src/app/styles/base.module.css
+++ b/src/app/styles/base.module.css
@@ -4,7 +4,7 @@
 }
 
 .area {
-  @apply bg-surfaceContainerLowest rounded-2xl p-6 flex flex-col gap-4 relative h-fit border-secondaryContainer border;
+  @apply bg-surfaceContainerLowest rounded-2xl p-4 flex flex-col gap-4 relative h-fit border-secondaryContainer border;
 }
 
 .area.table {


### PR DESCRIPTION
- 공통/Main Title Height: 64px → 56px
- 공통/Sidebar Width: 80px → 72px
- 공통/Header ↔ Main Container Gap: 24px → 16px
- 공통/Main Container Horizonal Margin: 32px → 24px
- 공통/Content Area padding: 24px → 16px
- 공통/Basic Table의 Table ↔ Action-panel gap: 16px → 8px
- Booking Request, SI Edit/Section Title margin-bottom: 24px → 16px
- Booking Request, SI Edit Stepitem Width: 300px → 284px
- SI Edit/Parties Tab’s Components Gap: 24px → 16px + Divider(dotted)
- SI Edit/Container Tab의 Total Amout Component의 Bg-color를 Surface-container-low로 변경