### PR TITLE
20240923 Update

### DIFF
--- a/public/img_dropdown_arrow.svg
+++ b/public/img_dropdown_arrow.svg
@@ -1,6 +1,6 @@
 <svg width="43" height="49" viewBox="0 0 43 49" fill="none" xmlns="http://www.w3.org/2000/svg">
 <g filter="url(#filter0_d_2788_511848)">
-<path d="M24.2 26L19.2125 21.8437C18.0611 20.8842 18.0611 19.1158 19.2125 18.1563L24.2 14L24.2 26Z" fill="white"/>
+<path d="M24.2 26L19.2125 21.8437C18.0611 20.8842 18.0611 19.1158 19.2125 18.1563L24.2 14L24.2 26Z" fill="#DBEDF9"/>
 </g>
 <defs>
 <filter id="filter0_d_2788_511848" x="0.348633" y="0.8" width="41.8516" height="48" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">

--- a/src/app/components/common-dialog-hooks.tsx
+++ b/src/app/components/common-dialog-hooks.tsx
@@ -44,22 +44,32 @@ export const usePlaceInfoDialog = (portal?: string) => {
   };
 };
 
-export const useVesselInfoDialog = () => {
+export const useVesselInfoDialog = (portal?: string) => {
   const [isVesselInfoDialogOpen, setIsVesselInfoDialogOpen] = useState(false);
   const [currentVessel, setCurrentVessel] = useState<VesselInfoType>(
     {} as VesselInfoType
   );
 
   function renderDialog() {
-    return (
-      <Portal selector="#main-container">
+    if (portal) {
+      return (
+        <Portal selector={portal}>
+          <VesselInformationDialog
+            open={isVesselInfoDialogOpen}
+            handleOpen={setIsVesselInfoDialogOpen}
+            data={currentVessel}
+          />
+        </Portal>
+      );
+    } else {
+      return (
         <VesselInformationDialog
           open={isVesselInfoDialogOpen}
           handleOpen={setIsVesselInfoDialogOpen}
           data={currentVessel}
         />
-      </Portal>
-    );
+      );
+    }
   }
 
   return {
@@ -69,7 +79,7 @@ export const useVesselInfoDialog = () => {
   };
 };
 
-export const useVesselScheduleDialog = () => {
+export const useVesselScheduleDialog = (portal?: string) => {
   const [isVesselScheduleDialogOpen, setIsVesselScheduleDialogOpen] =
     useState(false);
   const [currentVessel, setCurrentVessel] = useState<VesselInfoType>(
@@ -77,18 +87,31 @@ export const useVesselScheduleDialog = () => {
   );
 
   function renderDialog() {
-    return (
-      currentVessel && (
-        <Portal selector="#main-container">
+    if (portal) {
+      return (
+        currentVessel && (
+          <Portal selector="#main-container">
+            <VesselScheduleDialog
+              open={isVesselScheduleDialogOpen}
+              handleOpen={setIsVesselScheduleDialogOpen}
+              vesselInfo={currentVessel}
+              vesselSchedules={createDummyVesselSchedules()}
+            />
+          </Portal>
+        )
+      );
+    } else {
+      return (
+        currentVessel && (
           <VesselScheduleDialog
             open={isVesselScheduleDialogOpen}
             handleOpen={setIsVesselScheduleDialogOpen}
             vesselInfo={currentVessel}
             vesselSchedules={createDummyVesselSchedules()}
           />
-        </Portal>
-      )
-    );
+        )
+      );
+    }
   }
 
   return {

--- a/src/app/components/label-chip.tsx
+++ b/src/app/components/label-chip.tsx
@@ -1,19 +1,23 @@
+import { MdRippleEffect } from "../util/md3";
 import { MdTypography } from "./typography";
 
 const LabelChip = ({
   label,
   className,
   size = "large",
+  onClick,
 }: {
   label: string;
   className?: string;
   size?: "small" | "medium" | "large";
+  onClick?: () => void;
 }) => {
   return (
     <MdTypography
       variant="label"
       size={size === "large" ? "large" : "medium"}
-      className={`h-fit min-h-fit rounded-lg inline-block overflow-hidden whitespace-nowrap text-ellipsis ${
+      onClick={onClick}
+      className={`relative h-fit min-h-fit rounded-lg inline-block overflow-hidden whitespace-nowrap text-ellipsis ${
         className || ""
       } ${
         size === "small"
@@ -25,8 +29,10 @@ const LabelChip = ({
           : ""
       } ${className?.includes("bg-") ? "" : "bg-primaryContainer"}
       ${className?.includes("text-") ? "" : "text-onPrimaryContainer"}
+      ${onClick ? "cursor-pointer" : ""}
       `}
     >
+      {onClick && <MdRippleEffect />}
       {label}
     </MdTypography>
   );

--- a/src/app/components/na-toggle-button.tsx
+++ b/src/app/components/na-toggle-button.tsx
@@ -25,7 +25,7 @@ export default function NaToggleButton({
       tag="label"
       variant="label"
       size="large"
-      className={` flex items-center cursor-pointer gap-0.5 my-1.5 min-w-fit ${className} ${
+      className={` flex items-center cursor-pointer gap-0.5 my-0.5 min-w-fit ${className} ${
         state === "disabled" || state === "disabled-checked"
           ? "text-outlineVariant"
           : "text-primary"

--- a/src/app/components/side-nav/nav-dropdown.tsx
+++ b/src/app/components/side-nav/nav-dropdown.tsx
@@ -185,7 +185,7 @@ const MenuComponent = ({
           >
             <div
               ref={refs.setFloating}
-              className="flex flex-col bg-white rounded-lg p-1 relative z-10"
+              className="flex flex-col bg-white rounded-lg relative z-10 w-[308px] max-w-[308px]"
               style={
                 {
                   "--md-elevation-level": 4,
@@ -197,11 +197,12 @@ const MenuComponent = ({
               <MdElevation />
               {!isNested && (
                 <>
-                  <div className="h-10 flex items-center">
+                  <div className="h-8 flex items-center bg-secondaryContainer rounded-t-lg">
                     <MdTypography
                       variant="label"
-                      size="large"
-                      className="flex-1 px-4"
+                      size="medium"
+                      prominent
+                      className="flex-1 px-4 text-outline"
                     >
                       {item.name}
                     </MdTypography>
@@ -209,7 +210,7 @@ const MenuComponent = ({
                   <div className="w-full h-px bg-surfaceVariant"></div>
                 </>
               )}
-              <div className="flex flex-col my-1">
+              <div className="flex flex-col mx-2 my-1">
                 {item.subMenu.map((subItem) =>
                   subItem.subMenu && subItem.subMenu.length > 0 ? (
                     <MenuComponent
@@ -220,7 +221,7 @@ const MenuComponent = ({
                   ) : (
                     <div
                       key={subItem.id}
-                      className="relative h-10 flex items-center pl-4 pr-2.5 cursor-pointer rounded-lg"
+                      className="relative h-10 flex items-center pl-4 pr-10 cursor-pointer rounded-full hover:font-bold"
                       role="menuitem"
                       {...getItemProps({
                         onClick(event) {
@@ -232,14 +233,10 @@ const MenuComponent = ({
                       })}
                     >
                       <MdRippleEffect />
-                      <MdTypography
-                        variant="label"
-                        size="large"
-                        className="flex-1"
-                      >
+                      <MdTypography variant="body" size="large">
                         {subItem.name}
                       </MdTypography>
-                      <MdIcon className="w-1 h-1 ml-8 rounded-full bg-surfaceVariant"></MdIcon>
+                      {/* <MdIcon className="w-1 h-1 ml-8 rounded-full bg-surfaceVariant"></MdIcon> */}
                     </div>
                   )
                 )}
@@ -247,7 +244,7 @@ const MenuComponent = ({
 
               <div
                 ref={arrowRef}
-                className={`absolute left-${middlewareData.arrow?.x} top-${middlewareData.arrow?.y} w-4 h-4 -ml-7 -mt-1`}
+                className={`absolute left-${middlewareData.arrow?.x} top-${middlewareData.arrow?.y} w-4 h-4 -ml-6 -mt-1`}
               >
                 <DropDownArrow />
               </div>

--- a/src/app/main/booking/request/components/bulk-container-input.tsx
+++ b/src/app/main/booking/request/components/bulk-container-input.tsx
@@ -74,7 +74,7 @@ const BulkContainerInput = ({
                         <div className="w-full border-dotted border-b border-b-outlineVariant mb-4"></div>
                       )}
                       <div className="flex gap-4">
-                        <div className="flex gap-2 flex-1">
+                        <div className="flex gap-2">
                           <NAOutlinedNumberField
                             className="w-[104px] min-w-[104px]"
                             label="Package"
@@ -91,7 +91,7 @@ const BulkContainerInput = ({
                             }}
                           />
                           <NAOutlinedListBox
-                            className="w-36"
+                            className="w-[296px]"
                             options={[
                               "Aerosol",
                               "Bag",
@@ -152,7 +152,7 @@ const BulkContainerInput = ({
                             }}
                           />
                         </div>
-                        <div className="flex gap-2">
+                        {/* <div className="flex gap-2">
                           <NAOutlinedNumberField
                             label="Net Weight"
                             className="w-[120px] min-w-[120px]"
@@ -187,7 +187,7 @@ const BulkContainerInput = ({
                               }));
                             }}
                           />
-                        </div>
+                        </div> */}
                         <MdOutlinedTextField
                           label="Commodity"
                           className="flex-1"
@@ -212,8 +212,9 @@ const BulkContainerInput = ({
                         />
                         <div className="flex gap-2">
                           <NAOutlinedNumberField
-                            className="w-24 min-w-24"
+                            className="w-[126px] min-w-[126px]"
                             label="Length"
+                            suffixText="cm"
                             value={container.length?.toString()}
                             handleValueChange={(value) => {
                               setContainerInformation((prev) => ({
@@ -227,8 +228,9 @@ const BulkContainerInput = ({
                             }}
                           />
                           <NAOutlinedNumberField
-                            className="w-24 min-w-24"
+                            className="w-[126px] min-w-[126px]"
                             label="Width"
+                            suffixText="cm"
                             value={container.width?.toString()}
                             handleValueChange={(value) => {
                               setContainerInformation((prev) => ({
@@ -242,8 +244,9 @@ const BulkContainerInput = ({
                             }}
                           />
                           <NAOutlinedNumberField
-                            className="w-24 min-w-24"
+                            className="w-[126px] min-w-[126px]"
                             label="Height"
+                            suffixText="cm"
                             value={container.height?.toString()}
                             handleValueChange={(value) => {
                               setContainerInformation((prev) => ({
@@ -256,7 +259,7 @@ const BulkContainerInput = ({
                               }));
                             }}
                           />
-                          <NAOutlinedListBox
+                          {/* <NAOutlinedListBox
                             label="Unit"
                             className="w-24"
                             initialValue={container.unit}
@@ -271,7 +274,7 @@ const BulkContainerInput = ({
                                 ),
                               }));
                             }}
-                          />
+                          /> */}
                         </div>
                       </div>
                       <div className="flex gap-4">

--- a/src/app/main/booking/request/components/dangerous-cargo-input.tsx
+++ b/src/app/main/booking/request/components/dangerous-cargo-input.tsx
@@ -163,7 +163,18 @@ const DangerousCargoInput = ({
       />
       {container.isDangerous && (
         <div className="flex flex-col gap-3">
-          <div className="flex gap-2 items-center">
+          <div className="flex gap-2">
+            <MdOutlinedIconButton
+              className="w-8 h-8 min-w-8"
+              onClick={() => {
+                AddDangerousCargo();
+              }}
+            >
+              <MdIcon>
+                <Add />
+              </MdIcon>
+            </MdOutlinedIconButton>
+
             <MdChipSet className="flex flex-row">
               {container.dangerousCargoInformation.map((dci, index) => (
                 <MdFilterChip
@@ -180,16 +191,6 @@ const DangerousCargoInput = ({
                 />
               ))}
             </MdChipSet>
-            <MdOutlinedIconButton
-              className="w-8 h-8"
-              onClick={() => {
-                AddDangerousCargo();
-              }}
-            >
-              <MdIcon>
-                <Add />
-              </MdIcon>
-            </MdOutlinedIconButton>
           </div>
           <div className="flex gap-4">
             {selectedDangerousCargo !== "" && (

--- a/src/app/main/booking/request/components/dangerous-cargo-input.tsx
+++ b/src/app/main/booking/request/components/dangerous-cargo-input.tsx
@@ -162,7 +162,7 @@ const DangerousCargoInput = ({
         }}
       />
       {container.isDangerous && (
-        <div className="flex flex-col gap-6">
+        <div className="flex flex-col gap-3">
           <div className="flex gap-2 items-center">
             <MdChipSet className="flex flex-row">
               {container.dangerousCargoInformation.map((dci, index) => (

--- a/src/app/main/documents/si/edit/components/container-input.tsx
+++ b/src/app/main/documents/si/edit/components/container-input.tsx
@@ -171,147 +171,148 @@ export default function ContainerInput({
 
   return (
     <div className="flex gap-4">
-      <div className="mt-6 flex flex-col gap-4">
+      <div className="mt-6 flex flex-col">
         {!isLastItem && (
           <div className="w-full border-dotted border-b border-b-outlineVariant mb-4"></div>
         )}
+        <div className="flex flex-col gap-4">
+          <div className="flex gap-4">
+            <div className="flex gap-2 items-start">
+              <NAOutlinedTextField
+                label="Type"
+                className="w-[216px]"
+                readOnly
+                value={`${
+                  container.containerType === ContainerType.dry
+                    ? "Dry"
+                    : container.containerType === ContainerType.reefer
+                    ? "Reefer"
+                    : container.containerType === ContainerType.opentop
+                    ? "Open Top"
+                    : container.containerType === ContainerType.flatrack
+                    ? "Flat Rack"
+                    : container.containerType === ContainerType.tank
+                    ? "Tank"
+                    : "Bulk"
+                } #${containerIndex + 1}`}
+              />
+              <NAOutlinedTextField
+                label="Container No."
+                maxInputLength={14}
+                className="w-[216px]"
+                value={container.containerNumber}
+                handleValueChange={(value) => {
+                  updateContainerStore(container, "containerNumber", value);
+                }}
+              />
+              <NAOutlinedListBox
+                suffixText="ft"
+                label="Size"
+                className="w-52"
+                initialValue={container.containerSize}
+                options={["20", "40", "40HC", "45"]}
+                onSelection={(size) => {
+                  updateContainerStore(container, "containerSize", size);
+                }}
+              />
+              <NAOutlinedListBox
+                label="S.O.C"
+                className="w-24"
+                initialValue={container.isSocContainer ? "Y" : "N"}
+                options={["Y", "N"]}
+                onSelection={(value) => {
+                  updateContainerStore(
+                    container,
+                    "isSocContainer",
+                    value === "Y"
+                  );
+                }}
+              />
+            </div>
+            <SealTextField
+              initialSealData={container.sealData}
+              onUpdated={(newSealData) => {
+                updateContainerStore(container, "sealData", newSealData);
+              }}
+            />
+          </div>
 
-        <div className="flex gap-4">
-          <div className="flex gap-2 items-start">
-            <NAOutlinedTextField
-              label="Type"
-              className="w-[216px]"
-              readOnly
-              value={`${
-                container.containerType === ContainerType.dry
-                  ? "Dry"
-                  : container.containerType === ContainerType.reefer
-                  ? "Reefer"
-                  : container.containerType === ContainerType.opentop
-                  ? "Open Top"
-                  : container.containerType === ContainerType.flatrack
-                  ? "Flat Rack"
-                  : container.containerType === ContainerType.tank
-                  ? "Tank"
-                  : "Bulk"
-              } #${containerIndex + 1}`}
-            />
-            <NAOutlinedTextField
-              label="Container No."
-              maxInputLength={14}
-              className="w-[216px]"
-              value={container.containerNumber}
-              handleValueChange={(value) => {
-                updateContainerStore(container, "containerNumber", value);
-              }}
-            />
-            <NAOutlinedListBox
-              suffixText="ft"
-              label="Size"
-              className="w-52"
-              initialValue={container.containerSize}
-              options={["20", "40", "40HC", "45"]}
-              onSelection={(size) => {
-                updateContainerStore(container, "containerSize", size);
-              }}
-            />
-            <NAOutlinedListBox
-              label="S.O.C"
-              className="w-24"
-              initialValue={container.isSocContainer ? "Y" : "N"}
-              options={["Y", "N"]}
-              onSelection={(value) => {
-                updateContainerStore(
-                  container,
-                  "isSocContainer",
-                  value === "Y"
-                );
-              }}
-            />
-          </div>
-          <SealTextField
-            initialSealData={container.sealData}
-            onUpdated={(newSealData) => {
-              updateContainerStore(container, "sealData", newSealData);
-            }}
-          />
-        </div>
-
-        <div className="flex gap-4">
-          <div className="flex gap-2 flex-1">
-            <NAOutlinedNumberField
-              value={container.packageQuantity?.toString()}
-              readOnly={container.hasCargoManifest}
-              label="Package"
-              className="w-[216px]"
-              maxInputLength={16}
-              handleValueChange={(value) => {
-                updateContainerStore(container, "packageQuantity", value);
-              }}
-            />
-            <NAOutlinedAutoComplete
-              className="w-[536px]"
-              readOnly={container.hasCargoManifest}
-              itemList={tempPackageList}
-              placeholder="Package Type"
-              initialValue={container.packageType}
-              isAllowOnlyListItems={false}
-              showAllonFocus
-              onQueryChange={(value) => {
-                updateContainerStore(container, "packageType", value);
-              }}
-              onItemSelection={(value) => {
-                updateContainerStore(container, "packageType", value);
-              }}
-            />
-          </div>
-          <div className="flex gap-2 ">
-            <NAOutlinedNumberField
-              label="Weight"
-              value={container.packageWeight?.toString() ?? ""}
-              readOnly={container.hasCargoManifest}
-              maxInputLength={22}
-              className="flex-1"
-              handleValueChange={(value) => {
-                updateContainerStore(container, "packageWeight", value);
-              }}
-            />
-            <NAOutlinedListBox
-              initialValue={SIEditContainerStore.weightUnit}
-              options={["KGS", "LBS"]}
-              className="w-28"
-              readOnly={container.hasCargoManifest}
-              onSelection={(value) => {
-                setSIEditContainerStore((prev) => ({
-                  ...prev,
-                  weightUnit: value as "KGS" | "LBS",
-                }));
-              }}
-            />
-          </div>
-          <div className="flex gap-2">
-            <NAOutlinedNumberField
-              label="Measure"
-              className="flex-1"
-              maxInputLength={16}
-              value={container.packageMeasurement?.toString()}
-              readOnly={container.hasCargoManifest}
-              handleValueChange={(value) => {
-                updateContainerStore(container, "packageMeasurement", value);
-              }}
-            />
-            <NAOutlinedListBox
-              initialValue={SIEditContainerStore.measurementUnit}
-              options={["CBM", "CBF"]}
-              className="w-28"
-              readOnly={container.hasCargoManifest}
-              onSelection={(value) => {
-                setSIEditContainerStore((prev) => ({
-                  ...prev,
-                  measurementUnit: value as "CBM" | "CBF",
-                }));
-              }}
-            />
+          <div className="flex gap-4">
+            <div className="flex gap-2 flex-1">
+              <NAOutlinedNumberField
+                value={container.packageQuantity?.toString()}
+                readOnly={container.hasCargoManifest}
+                label="Package"
+                className="w-[216px]"
+                maxInputLength={16}
+                handleValueChange={(value) => {
+                  updateContainerStore(container, "packageQuantity", value);
+                }}
+              />
+              <NAOutlinedAutoComplete
+                className="w-[536px]"
+                readOnly={container.hasCargoManifest}
+                itemList={tempPackageList}
+                placeholder="Package Type"
+                initialValue={container.packageType}
+                isAllowOnlyListItems={false}
+                showAllonFocus
+                onQueryChange={(value) => {
+                  updateContainerStore(container, "packageType", value);
+                }}
+                onItemSelection={(value) => {
+                  updateContainerStore(container, "packageType", value);
+                }}
+              />
+            </div>
+            <div className="flex gap-2 ">
+              <NAOutlinedNumberField
+                label="Weight"
+                value={container.packageWeight?.toString() ?? ""}
+                readOnly={container.hasCargoManifest}
+                maxInputLength={22}
+                className="flex-1"
+                handleValueChange={(value) => {
+                  updateContainerStore(container, "packageWeight", value);
+                }}
+              />
+              <NAOutlinedListBox
+                initialValue={SIEditContainerStore.weightUnit}
+                options={["KGS", "LBS"]}
+                className="w-28"
+                readOnly={container.hasCargoManifest}
+                onSelection={(value) => {
+                  setSIEditContainerStore((prev) => ({
+                    ...prev,
+                    weightUnit: value as "KGS" | "LBS",
+                  }));
+                }}
+              />
+            </div>
+            <div className="flex gap-2">
+              <NAOutlinedNumberField
+                label="Measure"
+                className="flex-1"
+                maxInputLength={16}
+                value={container.packageMeasurement?.toString()}
+                readOnly={container.hasCargoManifest}
+                handleValueChange={(value) => {
+                  updateContainerStore(container, "packageMeasurement", value);
+                }}
+              />
+              <NAOutlinedListBox
+                initialValue={SIEditContainerStore.measurementUnit}
+                options={["CBM", "CBF"]}
+                className="w-28"
+                readOnly={container.hasCargoManifest}
+                onSelection={(value) => {
+                  setSIEditContainerStore((prev) => ({
+                    ...prev,
+                    measurementUnit: value as "CBM" | "CBF",
+                  }));
+                }}
+              />
+            </div>
           </div>
         </div>
 
@@ -359,271 +360,273 @@ export default function ContainerInput({
             </div>
           </MdDialog>
         </Portal>
-        <NaToggleButton
-          className="w-fit my-0"
-          label="Cargo Manifest"
-          state={container.hasCargoManifest ? "checked" : "unchecked"}
-          onClick={(isChecked) => {
-            if (isChecked) {
-              setIsWarningRemoveCargoManifestDialogOpen(true);
-            } else {
-              updateContainerStore(container, "hasCargoManifest", !isChecked);
-              if (container.cargoManifest.length === 0) {
-                addNewCargoManifestToContainer();
-              }
-            }
-          }}
-        />
-        {container.hasCargoManifest && (
-          <>
-            <div className="flex gap-2 flex-1">
-              <MdChipSet className="flex-row">
-                {
-                  // display CargoManifest
-                  container.cargoManifest.map((cargo, i) => {
-                    return (
-                      <div key={cargo.uuid}>
-                        <MdFilterChip
-                          style={
-                            {
-                              "--md-filter-chip-selected-container-color":
-                                "var(--md-sys-point-color)",
-                            } as CSSProperties
-                          }
-                          label={`Cargo #${i + 1}`}
-                          selected={selectedCargoManifestUuid === cargo.uuid}
-                          onClick={() => {
-                            if (selectedCargoManifestUuid === cargo.uuid) {
-                              setSelectedCargoManifestUuid("");
-                            } else {
-                              setSelectedCargoManifestUuid(cargo.uuid);
-                            }
-                          }}
-                          remove={(e) => {
-                            removeCargoManifestFromContainer(cargo.uuid);
-                          }}
-                          removable
-                        />
-                      </div>
-                    );
-                  })
-                }
-              </MdChipSet>
-              <MdOutlinedIconButton
-                className="w-8 h-8 min-w-8"
-                onClick={() => {
+        <div className="flex flex-col gap-2 mt-2">
+          <NaToggleButton
+            className="w-fit"
+            label="Cargo Manifest"
+            state={container.hasCargoManifest ? "checked" : "unchecked"}
+            onClick={(isChecked) => {
+              if (isChecked) {
+                setIsWarningRemoveCargoManifestDialogOpen(true);
+              } else {
+                updateContainerStore(container, "hasCargoManifest", !isChecked);
+                if (container.cargoManifest.length === 0) {
                   addNewCargoManifestToContainer();
-                }}
-              >
-                <Add fontSize="small" />
-              </MdOutlinedIconButton>
-            </div>
-            {container.cargoManifest.find(
-              (cm) => cm.uuid === selectedCargoManifestUuid
-            ) && (
-              <>
-                <div className="flex gap-4 flex-1">
-                  <div className="flex gap-2 flex-1">
-                    <NAOutlinedNumberField
-                      label="Package"
-                      className="w-[104px]"
-                      maxInputLength={16}
-                      value={container.cargoManifest
-                        .find((cm) => cm.uuid === selectedCargoManifestUuid)
-                        ?.packageQuantity?.toString()}
-                      handleValueChange={(value) => {
-                        updateContainerStore(
-                          container,
-                          "cargoManifest",
-                          container.cargoManifest.map((cm) =>
-                            cm.uuid === selectedCargoManifestUuid
-                              ? {
-                                  ...cm,
-                                  packageQuantity: value,
-                                }
-                              : cm
-                          )
-                        );
-                      }}
-                    />
-                    <NAOutlinedAutoComplete
-                      placeholder="Package"
-                      className="w-40"
-                      itemList={tempPackageList}
-                      initialValue={
-                        container.cargoManifest.find(
-                          (cm) => cm.uuid === selectedCargoManifestUuid
-                        )?.packageType || ""
-                      }
-                      isAllowOnlyListItems={false}
-                      showAllonFocus
-                      onQueryChange={(value) => {
-                        updateContainerStore(
-                          container,
-                          "cargoManifest",
-                          container.cargoManifest.map((cm) =>
-                            cm.uuid === selectedCargoManifestUuid
-                              ? {
-                                  ...cm,
-                                  packageType: value,
-                                }
-                              : cm
-                          )
-                        );
-                      }}
-                      onItemSelection={(value) => {
-                        updateContainerStore(
-                          container,
-                          "cargoManifest",
-                          container.cargoManifest.map((cm) =>
-                            cm.uuid === selectedCargoManifestUuid
-                              ? {
-                                  ...cm,
-                                  packageType: value,
-                                }
-                              : cm
-                          )
-                        );
-                      }}
-                    />
-                    <NAOutlinedNumberField
-                      label="Weight"
-                      maxInputLength={22}
-                      className="w-[104px]"
-                      value={container.cargoManifest
-                        .find((cm) => cm.uuid === selectedCargoManifestUuid)
-                        ?.weight?.toString()}
-                      handleValueChange={(value) => {
-                        updateContainerStore(
-                          container,
-                          "cargoManifest",
-                          container.cargoManifest.map((cm) =>
-                            cm.uuid === selectedCargoManifestUuid
-                              ? {
-                                  ...cm,
-                                  weight: value,
-                                }
-                              : cm
-                          )
-                        );
-                      }}
-                    />
-                    <NAOutlinedListBox
-                      options={["KGS", "LBS"]}
-                      className="w-28"
-                      initialValue={SIEditContainerStore.weightUnit}
-                      onSelection={(value) => {
-                        setSIEditContainerStore((prev) => ({
-                          ...prev,
-                          weightUnit: value as "KGS" | "LBS",
-                        }));
-                      }}
-                    />
-                    <NAOutlinedNumberField
-                      label="Measure"
-                      className="w-[104px]"
-                      maxInputLength={16}
-                      value={container.cargoManifest
-                        .find((cm) => cm.uuid === selectedCargoManifestUuid)
-                        ?.measurement?.toString()}
-                      handleValueChange={(value) => {
-                        updateContainerStore(
-                          container,
-                          "cargoManifest",
-                          container.cargoManifest.map((cm) =>
-                            cm.uuid === selectedCargoManifestUuid
-                              ? {
-                                  ...cm,
-                                  measurement: value,
-                                }
-                              : cm
-                          )
-                        );
-                      }}
-                    />
-                    <NAOutlinedListBox
-                      options={["CBM", "CBF"]}
-                      className="w-28"
-                      initialValue={SIEditContainerStore.measurementUnit}
-                      onSelection={(value) => {
-                        setSIEditContainerStore((prev) => ({
-                          ...prev,
-                          measurementUnit: value as "CBM" | "CBF",
-                        }));
-                      }}
-                    />
-                    <NAOutlinedTextField
-                      label="Description of Goods"
-                      className="flex-1"
-                    />
+                }
+              }
+            }}
+          />
+          {container.hasCargoManifest && (
+            <>
+              <div className="flex gap-2 flex-1">
+                <MdOutlinedIconButton
+                  className="w-8 h-8 min-w-8"
+                  onClick={() => {
+                    addNewCargoManifestToContainer();
+                  }}
+                >
+                  <Add fontSize="small" />
+                </MdOutlinedIconButton>
+                <MdChipSet className="flex-row mb-2">
+                  {
+                    // display CargoManifest
+                    container.cargoManifest.map((cargo, i) => {
+                      return (
+                        <div key={cargo.uuid}>
+                          <MdFilterChip
+                            style={
+                              {
+                                "--md-filter-chip-selected-container-color":
+                                  "var(--md-sys-point-color)",
+                              } as CSSProperties
+                            }
+                            label={`Cargo #${i + 1}`}
+                            selected={selectedCargoManifestUuid === cargo.uuid}
+                            onClick={() => {
+                              if (selectedCargoManifestUuid === cargo.uuid) {
+                                setSelectedCargoManifestUuid("");
+                              } else {
+                                setSelectedCargoManifestUuid(cargo.uuid);
+                              }
+                            }}
+                            remove={(e) => {
+                              removeCargoManifestFromContainer(cargo.uuid);
+                            }}
+                            removable
+                          />
+                        </div>
+                      );
+                    })
+                  }
+                </MdChipSet>
+              </div>
+              {container.cargoManifest.find(
+                (cm) => cm.uuid === selectedCargoManifestUuid
+              ) && (
+                <>
+                  <div className="flex gap-4 flex-1">
+                    <div className="flex gap-2 flex-1">
+                      <NAOutlinedNumberField
+                        label="Package"
+                        className="w-[104px]"
+                        maxInputLength={16}
+                        value={container.cargoManifest
+                          .find((cm) => cm.uuid === selectedCargoManifestUuid)
+                          ?.packageQuantity?.toString()}
+                        handleValueChange={(value) => {
+                          updateContainerStore(
+                            container,
+                            "cargoManifest",
+                            container.cargoManifest.map((cm) =>
+                              cm.uuid === selectedCargoManifestUuid
+                                ? {
+                                    ...cm,
+                                    packageQuantity: value,
+                                  }
+                                : cm
+                            )
+                          );
+                        }}
+                      />
+                      <NAOutlinedAutoComplete
+                        placeholder="Package"
+                        className="w-40"
+                        itemList={tempPackageList}
+                        initialValue={
+                          container.cargoManifest.find(
+                            (cm) => cm.uuid === selectedCargoManifestUuid
+                          )?.packageType || ""
+                        }
+                        isAllowOnlyListItems={false}
+                        showAllonFocus
+                        onQueryChange={(value) => {
+                          updateContainerStore(
+                            container,
+                            "cargoManifest",
+                            container.cargoManifest.map((cm) =>
+                              cm.uuid === selectedCargoManifestUuid
+                                ? {
+                                    ...cm,
+                                    packageType: value,
+                                  }
+                                : cm
+                            )
+                          );
+                        }}
+                        onItemSelection={(value) => {
+                          updateContainerStore(
+                            container,
+                            "cargoManifest",
+                            container.cargoManifest.map((cm) =>
+                              cm.uuid === selectedCargoManifestUuid
+                                ? {
+                                    ...cm,
+                                    packageType: value,
+                                  }
+                                : cm
+                            )
+                          );
+                        }}
+                      />
+                      <NAOutlinedNumberField
+                        label="Weight"
+                        maxInputLength={22}
+                        className="w-[104px]"
+                        value={container.cargoManifest
+                          .find((cm) => cm.uuid === selectedCargoManifestUuid)
+                          ?.weight?.toString()}
+                        handleValueChange={(value) => {
+                          updateContainerStore(
+                            container,
+                            "cargoManifest",
+                            container.cargoManifest.map((cm) =>
+                              cm.uuid === selectedCargoManifestUuid
+                                ? {
+                                    ...cm,
+                                    weight: value,
+                                  }
+                                : cm
+                            )
+                          );
+                        }}
+                      />
+                      <NAOutlinedListBox
+                        options={["KGS", "LBS"]}
+                        className="w-28"
+                        initialValue={SIEditContainerStore.weightUnit}
+                        onSelection={(value) => {
+                          setSIEditContainerStore((prev) => ({
+                            ...prev,
+                            weightUnit: value as "KGS" | "LBS",
+                          }));
+                        }}
+                      />
+                      <NAOutlinedNumberField
+                        label="Measure"
+                        className="w-[104px]"
+                        maxInputLength={16}
+                        value={container.cargoManifest
+                          .find((cm) => cm.uuid === selectedCargoManifestUuid)
+                          ?.measurement?.toString()}
+                        handleValueChange={(value) => {
+                          updateContainerStore(
+                            container,
+                            "cargoManifest",
+                            container.cargoManifest.map((cm) =>
+                              cm.uuid === selectedCargoManifestUuid
+                                ? {
+                                    ...cm,
+                                    measurement: value,
+                                  }
+                                : cm
+                            )
+                          );
+                        }}
+                      />
+                      <NAOutlinedListBox
+                        options={["CBM", "CBF"]}
+                        className="w-28"
+                        initialValue={SIEditContainerStore.measurementUnit}
+                        onSelection={(value) => {
+                          setSIEditContainerStore((prev) => ({
+                            ...prev,
+                            measurementUnit: value as "CBM" | "CBF",
+                          }));
+                        }}
+                      />
+                      <NAOutlinedTextField
+                        label="Description of Goods"
+                        className="flex-1"
+                      />
+                    </div>
+                    <div className="flex gap-2">
+                      <NAOutlinedNumberField
+                        label="HTS Code(EU, ASIA)"
+                        maxInputLength={6}
+                        className="w-[184px]"
+                        placeholder="Code"
+                        hideZeroPlaceholder
+                        enableNumberSeparator={false}
+                        value={
+                          container.cargoManifest.find(
+                            (cm) => cm.uuid === selectedCargoManifestUuid
+                          )?.commodityCode.hisCodeEUASIA || ""
+                        }
+                        handleValueChange={(value) => {
+                          updateContainerStore(
+                            container,
+                            "cargoManifest",
+                            container.cargoManifest.map((cm) =>
+                              cm.uuid === selectedCargoManifestUuid
+                                ? {
+                                    ...cm,
+                                    commodityCode: {
+                                      ...cm.commodityCode,
+                                      hisCodeEUASIA: value,
+                                    },
+                                  }
+                                : cm
+                            )
+                          );
+                        }}
+                      />
+                      <NAOutlinedNumberField
+                        label="HTS Code(U.S.)"
+                        maxInputLength={6}
+                        placeholder="Code"
+                        className="w-[136px]"
+                        hideZeroPlaceholder
+                        enableNumberSeparator={false}
+                        value={
+                          container.cargoManifest.find(
+                            (cm) => cm.uuid === selectedCargoManifestUuid
+                          )?.commodityCode.htsCodeUS || ""
+                        }
+                        handleValueChange={(value) => {
+                          updateContainerStore(
+                            container,
+                            "cargoManifest",
+                            container.cargoManifest.map((cm) =>
+                              cm.uuid === selectedCargoManifestUuid
+                                ? {
+                                    ...cm,
+                                    commodityCode: {
+                                      ...cm.commodityCode,
+                                      htsCodeUS: value,
+                                    },
+                                  }
+                                : cm
+                            )
+                          );
+                        }}
+                      />
+                    </div>
                   </div>
-                  <div className="flex gap-2">
-                    <NAOutlinedNumberField
-                      label="HTS Code(EU, ASIA)"
-                      maxInputLength={6}
-                      className="w-[184px]"
-                      placeholder="Code"
-                      hideZeroPlaceholder
-                      enableNumberSeparator={false}
-                      value={
-                        container.cargoManifest.find(
-                          (cm) => cm.uuid === selectedCargoManifestUuid
-                        )?.commodityCode.hisCodeEUASIA || ""
-                      }
-                      handleValueChange={(value) => {
-                        updateContainerStore(
-                          container,
-                          "cargoManifest",
-                          container.cargoManifest.map((cm) =>
-                            cm.uuid === selectedCargoManifestUuid
-                              ? {
-                                  ...cm,
-                                  commodityCode: {
-                                    ...cm.commodityCode,
-                                    hisCodeEUASIA: value,
-                                  },
-                                }
-                              : cm
-                          )
-                        );
-                      }}
-                    />
-                    <NAOutlinedNumberField
-                      label="HTS Code(U.S.)"
-                      maxInputLength={6}
-                      placeholder="Code"
-                      className="w-[136px]"
-                      hideZeroPlaceholder
-                      enableNumberSeparator={false}
-                      value={
-                        container.cargoManifest.find(
-                          (cm) => cm.uuid === selectedCargoManifestUuid
-                        )?.commodityCode.htsCodeUS || ""
-                      }
-                      handleValueChange={(value) => {
-                        updateContainerStore(
-                          container,
-                          "cargoManifest",
-                          container.cargoManifest.map((cm) =>
-                            cm.uuid === selectedCargoManifestUuid
-                              ? {
-                                  ...cm,
-                                  commodityCode: {
-                                    ...cm.commodityCode,
-                                    htsCodeUS: value,
-                                  },
-                                }
-                              : cm
-                          )
-                        );
-                      }}
-                    />
-                  </div>
-                </div>
-              </>
-            )}
-          </>
-        )}
+                </>
+              )}
+            </>
+          )}
+        </div>
       </div>
       <MdOutlinedIconButton
         className={`min-w-10 ${isLastItem ? "mt-8" : "mt-16"}`}

--- a/src/app/main/documents/si/edit/components/seal-textfield.tsx
+++ b/src/app/main/documents/si/edit/components/seal-textfield.tsx
@@ -371,7 +371,20 @@ const SealSettingDialog = ({
           setIsSettingDialogOpen(true);
         }}
       >
-        <AddCircleOutline />
+        {currentSealData.length > 1 ? (
+          <>
+            <MdTypography
+              variant="label"
+              size="large"
+              prominent
+              className="bg-outline text-white rounded-full flex items-center justify-center"
+            >{`+${currentSealData.length - 1}`}</MdTypography>
+          </>
+        ) : (
+          <>
+            <AddCircleOutline />
+          </>
+        )}
       </MdIconButton>
       <MdDialog
         open={isSettingDialogOpen}

--- a/src/app/main/documents/si/table.tsx
+++ b/src/app/main/documents/si/table.tsx
@@ -348,7 +348,7 @@ export default function SITable() {
   ];
 
   return (
-    <>
+    <div>
       {renderDialog()}
       <BasicTable
         ActionComponent={(table) => {
@@ -431,7 +431,7 @@ export default function SITable() {
           }
         }}
       />
-    </>
+    </div>
   );
 
   function handleSITableRowSelection(newRow: SISearchTableProps) {

--- a/src/app/main/import/master/table.tsx
+++ b/src/app/main/import/master/table.tsx
@@ -335,7 +335,7 @@ export const InboundMasterTable = () => {
   ];
 
   return (
-    <>
+    <div>
       {renderEstimatedTimeofDepartureDialog()}
       {renderDialog()}
       {renderPlaceDialog()}
@@ -370,6 +370,6 @@ export const InboundMasterTable = () => {
         }}
         isSingleSelect
       />
-    </>
+    </div>
   );
 };

--- a/src/app/main/schedule/long-range/table.tsx
+++ b/src/app/main/schedule/long-range/table.tsx
@@ -95,7 +95,7 @@ export default function LongRangeTable({
             key={i}
             className={`${
               hasDeparture ? "h-24" : "h-12"
-            } flex justify-between pb-px bg-surface border-b border-b-outlineVariant`}
+            } flex justify-between pb-px bg-surfaceContainerLowest border-b border-b-outlineVariant`}
           >
             <div className="flex p-2 flex-1 items-center">
               <div
@@ -190,7 +190,7 @@ export default function LongRangeTable({
                     key={j}
                     className={`${
                       hasDeparture ? "h-24" : "h-12"
-                    } col-span-1 border-b border-b-outlineVariant bg-surface flex flex-col`}
+                    } col-span-1 border-b border-b-outlineVariant bg-surfaceContainerLowest flex flex-col`}
                   >
                     <FloatingDelayGroup
                       delay={{

--- a/src/app/main/schedule/ptp/components/listItem.tsx
+++ b/src/app/main/schedule/ptp/components/listItem.tsx
@@ -40,6 +40,7 @@ import {
   useVesselScheduleDialog,
 } from "@/app/components/common-dialog-hooks";
 import { DividerComponent } from "@/app/components/divider";
+import Portal from "@/app/components/portal";
 
 export default function ListItem({
   item,
@@ -252,7 +253,7 @@ const VesselPortComponent = ({
     renderDialog: renderPlaceDialog,
     setCurrentPlace,
     setIsPlaceInfoDialogOpen,
-  } = usePlaceInfoDialog("#main-container");
+  } = usePlaceInfoDialog();
 
   return (
     <div className="flex w-full">

--- a/src/app/main/schedule/ptp/components/listItem.tsx
+++ b/src/app/main/schedule/ptp/components/listItem.tsx
@@ -2,7 +2,6 @@ import { DateTime } from "luxon";
 import { useEffect, useMemo, useState } from "react";
 
 import VesselIcon from "@/../public/icon_vessel.svg";
-import Portal from "@/app/components/portal";
 import { MdTypography } from "@/app/components/typography";
 import {
   MdElevationButton,
@@ -22,9 +21,6 @@ import ArrowForwardIosIcon from "@mui/icons-material/ArrowForwardIos";
 import ExpandMoreOutlinedIcon from "@mui/icons-material/ExpandMoreOutlined";
 import LocationOnIcon from "@mui/icons-material/LocationOn";
 
-import PlaceInformationDialog from "../../popup/place-information";
-import VesselInformationDialog from "../../popup/vessel-information";
-import VesselScheduleDialog from "../../popup/vessel-schedule";
 import {
   createDummyVesselSchedules,
   createDummyPlaceInformation,
@@ -38,6 +34,12 @@ import {
   VesselInfoType,
 } from "@/app/util/typeDef/schedule";
 import { DetailTitle } from "@/app/components/title-components";
+import {
+  usePlaceInfoDialog,
+  useVesselInfoDialog,
+  useVesselScheduleDialog,
+} from "@/app/components/common-dialog-hooks";
+import { DividerComponent } from "@/app/components/divider";
 
 export default function ListItem({
   item,
@@ -50,151 +52,7 @@ export default function ListItem({
   onPlaceInformationClick?: (place: PlaceInformationType) => void;
   onVesselInformationClick?: (vessel: VesselInfoType) => void;
 }) {
-  // const [isPlaceInformationOpen, setIsPlaceInformationOpen] = useState(false);
-  // const [isVesselInformationOpen, setIsVesselInformationOpen] = useState(false);
-  const [selectedPlace, setSelectedPlace] = useState<PlaceInformationType>();
   const [isDetailOpen, setIsDetailOpen] = useState(false);
-
-  const VesselPortComponent = ({
-    item,
-    time,
-    portState = "middle",
-  }: {
-    item: PlaceInformationType;
-    time: DateTime;
-    cutOff?: CutOffDataType;
-    portState?: "origin" | "middle" | "destination";
-  }) => {
-    return (
-      <div className="flex items-center w-full">
-        {portState === "origin" || portState === "destination" ? (
-          <FmdGood className="text-primary" />
-        ) : (
-          <FmdGoodOutlined className="text-primary" />
-        )}
-        <div className="ml-6 flex-1">
-          <div className="flex items-center gap-2">
-            <div className="flex flex-1 gap-2 items-center">
-              <MdTypography
-                variant="body"
-                size="large"
-                prominent
-                className="text-primary"
-              >
-                {item.yardName.toUpperCase()}
-              </MdTypography>
-              <MdTypography
-                variant="body"
-                size="medium"
-                className="text-outline"
-              >
-                {time.toFormat("yyyy-MM-dd HH:mm")}
-              </MdTypography>
-            </div>
-          </div>
-          <div
-            className="w-fit"
-            onClick={() => {
-              // setSelectedPlace(item);
-              // setIsPlaceInformationOpen(!isPlaceInformationOpen);
-              onPlaceInformationClick?.(item);
-            }}
-          >
-            <MdTypography
-              variant="body"
-              size="medium"
-              className="text-onSurfaceVariant underline cursor-pointer"
-            >
-              {item.address}
-            </MdTypography>
-          </div>
-        </div>
-        {portState === "origin" && (
-          <div className="h-12 border-l border-l-outlineVariant flex items-center text-primary">
-            <AccessTime className="ml-4 mr-2" fontSize="small" />
-            <MdTypography variant="label" size="large" className="mr-8">
-              Cut Off
-            </MdTypography>
-            <div className="flex gap-6 mr-6">
-              <BasicDetailItem
-                title="Documentation"
-                value={cutoffData.documentation.toFormat("yyyy-MM-dd HH:mm")}
-              />
-              <BasicDetailItem
-                title="EDI"
-                value={cutoffData.EDI.toFormat("yyyy-MM-dd HH:mm")}
-              />
-              <BasicDetailItem
-                title="Cargo"
-                value={cutoffData.cargo.toFormat("yyyy-MM-dd HH:mm")}
-              />
-            </div>
-          </div>
-        )}
-      </div>
-    );
-  };
-
-  const VesselRouteComponent = () => {
-    const data = useMemo(() => {
-      return {
-        vesselLine: faker.airline.airplane().name,
-        serviceLane: faker.string.alphanumeric(4).toUpperCase(),
-        transitTime: faker.number.int({
-          max: 10,
-        }),
-      };
-    }, []);
-
-    return (
-      <div className="flex items-center relative">
-        <div className="mr-6 bg-surfaceContainerLowest z-10 text-primary">
-          <ArrowDropDown />
-        </div>
-        <div className="border-r-2 border-r-outlineVariant border-dotted h-28 absolute left-3 -translate-x-px"></div>
-        <div className="bg-secondaryContainer rounded-2xl flex flex-1 px-8 py-2 gap-2 items-center">
-          <MdIcon className="text-primary">
-            <VesselIcon />
-          </MdIcon>
-          <div
-            onClick={() => {
-              onVesselScheduleClick?.(tempVesselInfo);
-            }}
-          >
-            <MdTypography
-              variant="body"
-              size="large"
-              className="underline text-onSurfaceVariant cursor-pointer"
-            >
-              {data.vesselLine}
-            </MdTypography>
-          </div>
-          <MdIconButton
-            onClick={() => {
-              // setIsVesselInformationOpen(true);
-              onVesselInformationClick?.(tempVesselInfo);
-            }}
-          >
-            <MdIcon>
-              <InfoOutlined />
-            </MdIcon>
-          </MdIconButton>
-          <div className="bg-onSecondary px-4 py-1 rounded-full ml-6">
-            <MdTypography variant="label" size="small">
-              {data.serviceLane}
-            </MdTypography>
-          </div>
-          <div className="w-px h-10 bg-outlineVariant mx-6"></div>
-          <MdTypography variant="label" size="medium" className="text-outline">
-            T/Time
-          </MdTypography>
-          <MdTypography variant="label" size="medium" prominent>
-            {data.transitTime} Hours
-          </MdTypography>
-        </div>
-      </div>
-    );
-  };
 
   const cutoffData = useMemo(() => {
     return {
@@ -219,39 +77,8 @@ export default function ListItem({
     };
   }, []);
 
-  const middleRoutes = useMemo(() => {
-    const portCount = faker.number.int({ min: 1, max: 3 });
-    return (
-      <>
-        {Array.from({ length: portCount }).map(() => {
-          return (
-            <>
-              <VesselRouteComponent />
-              <VesselPortComponent
-                item={createDummyPlaceInformation(faker.location.city())}
-                time={DateTime.fromJSDate(
-                  faker.date.between(
-                    item.departureDate.toJSDate(),
-                    item.arrivalDate.toJSDate()
-                  )
-                )}
-              />
-            </>
-          );
-        })}
-        <VesselRouteComponent />
-      </>
-    );
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [item.arrivalDate, item.departureDate]);
-
   const tempVesselInfo = useMemo(() => {
     return createDummyVesselInformation();
-  }, []);
-
-  const tempVesselSchedules = useMemo(() => {
-    return createDummyVesselSchedules();
   }, []);
 
   useEffect(() => {
@@ -281,8 +108,6 @@ export default function ListItem({
                 <span
                   className="border-b border-onSurface uppercase cursor-pointer"
                   onClick={() => {
-                    // setSelectedPlace(item.origin);
-                    // setIsPlaceInformationOpen(!isPlaceInformationOpen);
                     onPlaceInformationClick?.(item.origin);
                   }}
                 >
@@ -303,7 +128,6 @@ export default function ListItem({
                 <span
                   className="border-b border-onSurface cursor-pointer"
                   onClick={() => {
-                    // setIsVesselScheduleOpen(true);
                     onVesselScheduleClick?.(tempVesselInfo);
                   }}
                 >
@@ -332,8 +156,6 @@ export default function ListItem({
                 <span
                   className="border-b border-onSurface uppercase cursor-pointer"
                   onClick={() => {
-                    // setSelectedPlace(item.destination);
-                    // setIsPlaceInformationOpen(!isPlaceInformationOpen);
                     onPlaceInformationClick?.(item.destination);
                   }}
                 >
@@ -377,69 +199,13 @@ export default function ListItem({
           <div className="rounded-lg border border-outlineVariant py-6 px-4 bg-surfaceContainerLow">
             <div className="border border-outlineVariant bg-surfaceContainerLowest rounded-2xl overflow-hidden">
               <div className="h-2 bg-secondaryContainer"></div>
-              <div className="py-4 px-6 flex flex-col relative">
-                <div className="absolute top-4 right-6 flex gap-2 px-4 py-2 bg-background rounded-2xl">
-                  <MdTypography
-                    variant="label"
-                    size="medium"
-                    className="text-outline"
-                  >
-                    Total
-                  </MdTypography>
-                  <MdTypography variant="label" size="medium" prominent>
-                    {item.transitTime} Days
-                  </MdTypography>
-                  <MdTypography variant="label" size="medium" prominent>
-                    {`(Ocean: 7 Days, Land: 3 Days)`}
-                  </MdTypography>
-                </div>
-                <DetailTitle title="Route" />
-                <div className="flex flex-col gap-6 mt-6">
-                  <VesselPortComponent
-                    item={item.origin}
-                    time={item.departureDate}
-                    cutOff={cutoffData}
-                    portState="origin"
-                  />
-                  {middleRoutes}
-                  <VesselPortComponent
-                    item={item.destination}
-                    time={item.arrivalDate}
-                    portState="destination"
-                  />
-                </div>
-                <div className="h-px bg-outlineVariant my-10"></div>
-                <DetailTitle title="Container Yard Information" />
-                <div className="grid grid-cols-5 mt-6 gap-8">
-                  <BasicDetailItem
-                    title="Loading Terminal"
-                    value={detailInfo.cyInfo.loadingTerminal}
-                  />
-                  <BasicDetailItem
-                    title="Custom No."
-                    value={detailInfo.cyInfo.customNo}
-                  />
-                  <BasicDetailItem
-                    title="Import"
-                    value={detailInfo.cyInfo.import}
-                  />
-                </div>
-                <div className="h-px bg-outlineVariant my-10"></div>
-                <DetailTitle title="CSF Information" />
-                <div className="grid grid-cols-5 mt-6 gap-8">
-                  <BasicDetailItem
-                    title="Company Name"
-                    value={detailInfo.csfInfo.companyName}
-                  />
-                  <BasicDetailItem
-                    title="Title"
-                    value={detailInfo.csfInfo.title}
-                  />
-                  <BasicDetailItem
-                    title="Import"
-                    value={detailInfo.csfInfo.phone}
-                  />
-                </div>
+              <div className="px-6 py-4">
+                <ItemDetail
+                  item={item}
+                  cutoffData={cutoffData}
+                  detailInfo={detailInfo}
+                  vesselInfo={tempVesselInfo}
+                />
               </div>
             </div>
           </div>
@@ -464,6 +230,366 @@ const BasicDetailItem = ({
       <MdTypography variant="title" size="medium" className="text-onSurface">
         {value}
       </MdTypography>
+    </div>
+  );
+};
+
+const VesselPortComponent = ({
+  item,
+  // time,
+  eta,
+  etd,
+  cutOff,
+  portState = "middle",
+}: {
+  item: PlaceInformationType;
+  eta?: DateTime;
+  etd?: DateTime;
+  cutOff?: CutOffDataType;
+  portState?: "origin" | "middle" | "destination";
+}) => {
+  const {
+    renderDialog: renderPlaceDialog,
+    setCurrentPlace,
+    setIsPlaceInfoDialogOpen,
+  } = usePlaceInfoDialog("#main-container");
+
+  return (
+    <div className="flex w-full">
+      <div className="flex h-full items-start">
+        {portState === "origin" || portState === "destination" ? (
+          <FmdGood className="text-primary" />
+        ) : (
+          <FmdGoodOutlined className="text-primary" />
+        )}
+      </div>
+      <div className="ml-6 flex-1">
+        <div className="flex items-center gap-2">
+          <div className="flex flex-1 gap-2 items-center">
+            <MdTypography
+              variant="body"
+              size="large"
+              prominent
+              className="text-primary"
+            >
+              {item.yardName.toUpperCase()}
+            </MdTypography>
+            <DividerComponent orientation="vertical" className="h-4" />
+            {eta && (
+              <>
+                <MdTypography
+                  variant="label"
+                  size="medium"
+                  className="bg-surfaceContainerHigh px-2 py-0.5 rounded-lg"
+                >
+                  ETD
+                </MdTypography>
+                <MdTypography
+                  variant="body"
+                  size="medium"
+                  className="text-outline"
+                >
+                  {eta.toFormat("yyyy-MM-dd HH:mm") ?? ""}
+                </MdTypography>
+              </>
+            )}
+            {etd && (
+              <>
+                <MdTypography
+                  variant="label"
+                  size="medium"
+                  className="bg-surfaceContainerHigh px-2 py-0.5 rounded-lg"
+                >
+                  ETA
+                </MdTypography>
+                <MdTypography
+                  variant="body"
+                  size="medium"
+                  className="text-outline"
+                >
+                  {etd.toFormat("yyyy-MM-dd HH:mm")}
+                </MdTypography>
+              </>
+            )}
+          </div>
+        </div>
+        <div
+          className="w-fit"
+          onClick={() => {
+            setCurrentPlace(item);
+            setIsPlaceInfoDialogOpen(true);
+          }}
+        >
+          <MdTypography
+            variant="body"
+            size="medium"
+            className="text-onSurfaceVariant underline cursor-pointer"
+          >
+            {item.address}
+          </MdTypography>
+        </div>
+        {portState === "origin" && (
+          <div className="flex items-center text-primary mt-2">
+            <AccessTime
+              className="mr-0.5"
+              sx={{
+                fontSize: "16px",
+              }}
+            />
+            <MdTypography
+              variant="label"
+              size="medium"
+              prominent
+              className="mr-4"
+            >
+              Cut Off
+            </MdTypography>
+            <div className="flex gap-6 mr-6">
+              <div className="flex gap-2 items-center">
+                <MdTypography
+                  variant="label"
+                  size="medium"
+                  className="text-outline"
+                >
+                  Documentation
+                </MdTypography>
+                <MdTypography
+                  variant="title"
+                  size="small"
+                  className="text-onSurface"
+                >
+                  {cutOff?.documentation.toFormat("yyyy-MM-dd HH:mm") ?? ""}
+                </MdTypography>
+              </div>
+              <div className="flex gap-2 items-center">
+                <MdTypography
+                  variant="label"
+                  size="medium"
+                  className="text-outline"
+                >
+                  EDI
+                </MdTypography>
+                <MdTypography
+                  variant="title"
+                  size="small"
+                  className="text-onSurface"
+                >
+                  {cutOff?.EDI.toFormat("yyyy-MM-dd HH:mm") ?? ""}
+                </MdTypography>
+              </div>
+              <div className="flex gap-2 items-center">
+                <MdTypography
+                  variant="label"
+                  size="medium"
+                  className="text-outline"
+                >
+                  Cargo
+                </MdTypography>
+                <MdTypography
+                  variant="title"
+                  size="small"
+                  className="text-onSurface"
+                >
+                  {cutOff?.cargo.toFormat("yyyy-MM-dd HH:mm") ?? ""}
+                </MdTypography>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+      {renderPlaceDialog()}
+    </div>
+  );
+};
+
+const VesselRouteComponent = ({
+  tempVesselInfo,
+  isFirst = false,
+}: {
+  tempVesselInfo: VesselInfoType;
+  isFirst?: boolean;
+}) => {
+  const data = useMemo(() => {
+    return {
+      vesselLine: faker.airline.airplane().name,
+      serviceLane: faker.string.alphanumeric(4).toUpperCase(),
+      transitTime: faker.number.int({
+        max: 10,
+      }),
+    };
+  }, []);
+
+  const {
+    renderDialog,
+    setCurrentVessel: setVesselForScheduleDialog,
+    setIsVesselScheduleDialogOpen,
+  } = useVesselScheduleDialog();
+  const {
+    renderDialog: renderVesselDialog,
+    setCurrentVessel,
+    setIsVesselInfoDialogOpen,
+  } = useVesselInfoDialog();
+
+  return (
+    <div className="bg-inherit flex items-center relative">
+      <div className="mr-6 bg-inherit z-10 text-primary">
+        <ArrowDropDown />
+      </div>
+      <div
+        className={`border-r-2 border-r-outlineVariant border-dotted absolute left-3  -translate-x-px ${
+          isFirst ? "h-20 -translate-y-12" : "h-12 -translate-y-9"
+        }`}
+      ></div>
+      <div className="border-r-2 border-r-outlineVariant border-dotted h-7 absolute left-3 translate-y-7 -translate-x-px"></div>
+      <div className="bg-secondaryContainer rounded-2xl flex flex-1 px-4 py-1 gap-2 items-center">
+        <MdIcon className="text-primary">
+          <VesselIcon />
+        </MdIcon>
+        <div
+          onClick={() => {
+            setVesselForScheduleDialog(tempVesselInfo);
+            setIsVesselScheduleDialogOpen(true);
+          }}
+        >
+          <MdTypography
+            variant="body"
+            size="medium"
+            prominent
+            className="text-onSurfaceVariant cursor-pointer hover:underline"
+          >
+            {data.vesselLine}
+          </MdTypography>
+        </div>
+        <MdIconButton
+          onClick={() => {
+            setCurrentVessel(tempVesselInfo);
+            setIsVesselInfoDialogOpen(true);
+          }}
+        >
+          <MdIcon>
+            <InfoOutlined />
+          </MdIcon>
+        </MdIconButton>
+        <div className="bg-onSecondary px-2 py-1 rounded-full ml-2">
+          <MdTypography variant="label" size="small">
+            {data.serviceLane}
+          </MdTypography>
+        </div>
+        <DividerComponent orientation="vertical" className="h-4 mx-2" />
+        <MdTypography variant="label" size="medium" className="text-outline">
+          T/Time
+        </MdTypography>
+        <MdTypography variant="label" size="medium" prominent>
+          {data.transitTime} Hours
+        </MdTypography>
+      </div>
+      {renderDialog()}
+      {renderVesselDialog()}
+    </div>
+  );
+};
+
+export const ItemDetail = ({
+  item,
+  cutoffData,
+  detailInfo,
+  vesselInfo,
+}: {
+  vesselInfo: VesselInfoType | undefined;
+  item: PtPScheduleType;
+  cutoffData: CutOffDataType;
+  detailInfo: {
+    cyInfo: {
+      loadingTerminal: string;
+      customNo: string;
+      import: string;
+    };
+    csfInfo: {
+      companyName: string;
+      title: string;
+      phone: string;
+    };
+  };
+}) => {
+  const middleRoutes = useMemo(() => {
+    const portCount = faker.number.int({ min: 1, max: 3 });
+    return (
+      <>
+        {Array.from({ length: portCount }).map((_, index) => {
+          return (
+            <>
+              {vesselInfo && (
+                <VesselRouteComponent
+                  tempVesselInfo={vesselInfo}
+                  isFirst={index === 0}
+                />
+              )}
+              <VesselPortComponent
+                item={createDummyPlaceInformation(faker.location.city())}
+                eta={item.arrivalDate}
+                etd={item.departureDate}
+              />
+            </>
+          );
+        })}
+        {vesselInfo && <VesselRouteComponent tempVesselInfo={vesselInfo} />}
+      </>
+    );
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [item.arrivalDate, item.departureDate]);
+
+  return (
+    <div className="flex flex-col relative">
+      <div className="absolute top-4 right-6 flex gap-2 px-4 py-2 bg-background rounded-2xl">
+        <MdTypography variant="label" size="medium" className="text-outline">
+          Total
+        </MdTypography>
+        <MdTypography variant="label" size="medium" prominent>
+          {item.transitTime} Days
+        </MdTypography>
+        <MdTypography variant="label" size="medium" prominent>
+          {`(Ocean: 7 Days, Land: 3 Days)`}
+        </MdTypography>
+      </div>
+      <DetailTitle title="Route" />
+      <div className="flex flex-col gap-6 mt-6">
+        <VesselPortComponent
+          item={item.origin}
+          etd={item.departureDate}
+          cutOff={cutoffData}
+          portState="origin"
+        />
+        {middleRoutes}
+        <VesselPortComponent
+          item={item.destination}
+          eta={item.arrivalDate}
+          portState="destination"
+        />
+      </div>
+      <div className="h-px bg-outlineVariant my-4"></div>
+      <DetailTitle title="Container Yard Information" />
+      <div className="grid grid-cols-5 mt-4 gap-8">
+        <BasicDetailItem
+          title="Loading Terminal"
+          value={detailInfo.cyInfo.loadingTerminal}
+        />
+        <BasicDetailItem
+          title="Custom No."
+          value={detailInfo.cyInfo.customNo}
+        />
+        <BasicDetailItem title="Import" value={detailInfo.cyInfo.import} />
+      </div>
+      <div className="h-px bg-outlineVariant my-4"></div>
+      <DetailTitle title="CSF Information" />
+      <div className="grid grid-cols-5 mt-4 gap-8">
+        <BasicDetailItem
+          title="Company Name"
+          value={detailInfo.csfInfo.companyName}
+        />
+        <BasicDetailItem title="Title" value={detailInfo.csfInfo.title} />
+        <BasicDetailItem title="Import" value={detailInfo.csfInfo.phone} />
+      </div>
     </div>
   );
 };

--- a/src/app/main/schedule/summary-container.tsx
+++ b/src/app/main/schedule/summary-container.tsx
@@ -15,9 +15,9 @@ export default function SummaryContainer({
 
   return (
     <div
-      className={`fixed left-0 -translate-y-8 pb-2 overflow-hidden rounded-t-2xl z-10 ${
+      className={`fixed left-0 -translate-y-6 pb-2 overflow-hidden rounded-t-2xl z-10 ${
         userData.isAuthenticated
-          ? "translate-x-20 w-[calc(100%-80px)]"
+          ? "translate-x-[72px] w-[calc(100%-72px)]"
           : "w-full"
       }`}
     >

--- a/src/app/main/shipment/report/table.tsx
+++ b/src/app/main/shipment/report/table.tsx
@@ -157,7 +157,7 @@ export const ReportTable = () => {
   ];
 
   return (
-    <>
+    <div>
       {renderDialog()}
       <BasicTable
         ActionComponent={() => (
@@ -175,6 +175,6 @@ export const ReportTable = () => {
         columns={columnDefs}
         pinningColumns={["blNumber"]}
       />
-    </>
+    </div>
   );
 };


### PR DESCRIPTION
- Point to Point Schedule/ListItem Detail 영역 UI 변경
- Point to Point Schedule/ Calendar View의 Dialog의 신규 화면을 위해 Listitem Component의 Detail Component 및 Vessel Port Component 및 Vessel Route Component 모듈화 및 고도화 수행(공통 Dailog에서 분리하여 성능 영향)
- Point to Point Schedule/Calendar View의 신규 화면 제작
- Point to Point Schedule/Calendar View의 Detail 표기 방식을 List → Dialog로 변경
- Report/Content Area 상단 여백 삭제
- Inbound Master/Content Area 상단 여백 삭제
- Long Range Schedule/Table Backgroud Color: Surface → SurfaceContainerLowest
- Booking Request/Container Input-Bulk Type에서 Net Weight 관련 항목 삭제 및 Size 관련 Unit Selector 삭제, Width, Height, Length Textfield에 ‘cm’ suffix-text 추가
- Booking Request, SI Edit/Container Tab에서 Textfield의 라인 간격을 16px, Toggle Button 하위 컨텐츠 라인 간격은 8px로 조정
- Booking Request/Dangerous Cargo Input의 Add Button 위치를 왼쪽으로 변경(Size 고정 및 상단 고정 추가)
- SI Edit/Cargo Manifest Input의 Add Button 위치를 왼쪽으로 변경(Size 고정 및 상단 고정 추가)
- Side Menu 아이콘 클릭 시, Dropdown Menu Style 변경