### PR TITLE
Refactor typography size in nav-dropdown.tsx

### DIFF
--- a/src/app/components/side-nav/nav-dropdown.tsx
+++ b/src/app/components/side-nav/nav-dropdown.tsx
@@ -233,7 +233,7 @@ const MenuComponent = ({
                       })}
                     >
                       <MdRippleEffect />
-                      <MdTypography variant="body" size="large">
+                      <MdTypography variant="body" size="medium">
                         {subItem.name}
                       </MdTypography>
                       {/* <MdIcon className="w-1 h-1 ml-8 rounded-full bg-surfaceVariant"></MdIcon> */}


### PR DESCRIPTION
Refactor the typography size in the `nav-dropdown.tsx` file. The `MdTypography` component's variant has been changed to "body" and the size has been updated to "medium". This change ensures consistent typography across the application.